### PR TITLE
allow common-js dependencies

### DIFF
--- a/ui/angular.json
+++ b/ui/angular.json
@@ -34,7 +34,13 @@
               "node_modules/primeng/resources/primeng.min.css",
               "DCSA-Theme.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "allowedCommonJsDependencies": [
+              "buffer",
+              "crypto-js",
+              "js-cookie",
+              "isomorphic-unfetch"
+            ]
           },
           "configurations": {
             "production": {

--- a/ui/src/app/controller/services/mapping/timestamp-mapping.service.ts
+++ b/ui/src/app/controller/services/mapping/timestamp-mapping.service.ts
@@ -4,7 +4,7 @@ import {OperationsEventService} from "../ovs/operations-event.service";
 import {from, Observable} from "rxjs";
 import {TransportCall} from "../../../model/ovs/transport-call";
 import {Port} from "../../../model/portCall/port";
-import {concatMap, map, mergeMap, toArray} from "rxjs/internal/operators";
+import {concatMap, map, mergeMap, toArray} from "rxjs/operators";
 import {Globals} from "../../../model/portCall/globals";
 import {OperationsEventsToTimestampsPipe} from "../../pipes/operations-events-to-timestamps.pipe";
 import {Terminal} from "../../../model/portCall/terminal";


### PR DESCRIPTION
- Done to remove warnings related to common-js dependencies.
- Mainly caused by imports used in Cognito libary