### PR TITLE
Fix for undefined ports for load transport calls

### DIFF
--- a/ui/src/app/view/transport-calls-table/transport-calls-table.component.ts
+++ b/ui/src/app/view/transport-calls-table/transport-calls-table.component.ts
@@ -37,8 +37,10 @@ export class TransportCallsTableComponent implements OnInit {
               private translate: TranslateService) { }
 
   ngOnInit(): void {
-    this.portService.getPorts().pipe(take(1)).subscribe(ports => this.ports = ports);
-    this.loadTransportCalls()
+    this.portService.getPorts().pipe(take(1)).subscribe(ports => {
+      this.ports = ports
+      this.loadTransportCalls()
+    });
     this.portFilterService.portObservable.subscribe(port => {
       this.filterPort = port
       this.refreshTransportCalls()


### PR DESCRIPTION
There was an issue where loading Ports for each Transport Call on startup would fail because `this.globals.ports` had not yet been loaded.