### PR TITLE
removed facility type code from transport call table

### DIFF
--- a/ui/src/app/view/transport-calls-table/transport-calls-table.component.html
+++ b/ui/src/app/view/transport-calls-table/transport-calls-table.component.html
@@ -41,7 +41,7 @@
       <th style="width:20%">{{'general.transportCall.table.vesselName.label'| translate}}</th>
       <th style="width:15%">{{'general.transportCall.table.vesselImo.label'| translate}}</th>
       <th style="width:10%">{{'general.transportCall.table.UNLocationCode.secondLabel'| translate}}</th>
-      <th style="width:10%">{{'general.transportCall.table.facilityTypeCode.label'| translate}}</th>
+      <!-- <th style="width:10%">{{'general.transportCall.table.facilityTypeCode.label'| translate}}</th> -->
       <th style="width:15%">{{'general.table.header.terminalId.label'| translate}}</th>
       <th style="width:15%">{{'general.transportCall.table.estimatedDateofArrival.label'| translate}}</th>
       <th style="width:15%">{{'general.transportCall.table.carrierVoyageNumber.label'| translate}}</th>
@@ -53,7 +53,7 @@
       <td>{{transportCall.vesselName}}</td>
       <td>{{transportCall.vesselIMONumber}}</td>
       <td>{{transportCall.UNLocationCode}}</td>
-      <td>{{transportCall.facilityTypeCode}}</td>
+      <!-- <td>{{transportCall.facilityTypeCode}}</td> -->
       <td>{{transportCall.facilityCode}}</td>
       <td
       pTooltip ="UTC: {{(transportCall.estimatedDateofArrival | timestampToTimezone: transportCall.portOfCall: ports)[1]}}"


### PR DESCRIPTION
on request from Guido, the column should be removed as it confuses the user if it dosnt show POTE. 
Solution: either remove it or only show POTE.