### PR TITLE
DDT-1109: PortCallPart filter for timestamps 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Angular Cache
+.angular

--- a/src/app/controller/pipes/operations-event-to-timestamp.pipe.ts
+++ b/src/app/controller/pipes/operations-event-to-timestamp.pipe.ts
@@ -1,16 +1,16 @@
-import {Pipe, PipeTransform} from '@angular/core';
-import {OperationsEvent} from "../../model/jit/operations-event";
-import {MessageDirection} from "../../model/portCall/messageDirection";
-import {Port} from "../../model/portCall/port";
-import {Terminal} from "../../model/portCall/terminal";
-import {Vessel} from "../../model/portCall/vessel";
-import {Timestamp} from 'src/app/model/jit/timestamp';
-import {Publisher} from 'src/app/model/publisher';
-import {PublisherRole} from 'src/app/model/enums/publisherRole';
-import {FacilityTypeCode} from 'src/app/model/enums/facilityTypeCodeOPR';
-import {EventClassifierCode} from 'src/app/model/jit/eventClassifierCode';
-import {OperationsEventTypeCode} from 'src/app/model/enums/operationsEventTypeCode';
-import {TimestampDefinition} from "../../model/jit/timestamp-definition";
+import { Pipe, PipeTransform } from '@angular/core';
+import { OperationsEvent } from "../../model/jit/operations-event";
+import { MessageDirection } from "../../model/portCall/messageDirection";
+import { Port } from "../../model/portCall/port";
+import { Terminal } from "../../model/portCall/terminal";
+import { Vessel } from "../../model/portCall/vessel";
+import { Timestamp } from 'src/app/model/jit/timestamp';
+import { Publisher } from 'src/app/model/publisher';
+import { PublisherRole } from 'src/app/model/enums/publisherRole';
+import { FacilityTypeCode } from 'src/app/model/enums/facilityTypeCodeOPR';
+import { EventClassifierCode } from 'src/app/model/jit/eventClassifierCode';
+import { OperationsEventTypeCode } from 'src/app/model/enums/operationsEventTypeCode';
+import { TimestampDefinition } from "../../model/jit/timestamp-definition";
 
 @Pipe({
   name: 'operationsEventEventToTimestamp'
@@ -50,6 +50,7 @@ export class OperationsEventToTimestampPipe implements PipeTransform {
       transportCallID: string;
       uiReadByUser: boolean;
       vessel: number | Vessel;
+      transportCallReference: string;
     }
 
     timestamp.publisher = operationsEvent.publisher;
@@ -70,10 +71,11 @@ export class OperationsEventToTimestampPipe implements PipeTransform {
     timestamp.remark = operationsEvent.remark;
     timestamp.delayReasonCode = operationsEvent.delayReasonCode;
     timestamp.eventDeliveryStatus = operationsEvent.eventDeliveryStatus;
-    // Extras
+    // Extras   
     timestamp.timestampDefinition = timestampDefinitions?.get(operationsEvent.timestampDefinitionID)
     timestamp.logOfTimestamp = operationsEvent.eventCreatedDateTime;
     timestamp.transportCallID = operationsEvent.transportCall.transportCallID;
+    timestamp.transportCallReference = operationsEvent?.transportCall?.transportCallReference;
     timestamp.eventLocation = operationsEvent.eventLocation;
 
     return timestamp;

--- a/src/app/controller/pipes/timestamp-to-standardized-timestamp.ts
+++ b/src/app/controller/pipes/timestamp-to-standardized-timestamp.ts
@@ -32,6 +32,7 @@ export class TimestampToStandardizedtTimestampPipe implements PipeTransform {
       transportCallID: string;
       transportCall: TransportCall;
       identifyingCodes?: identifyingCodes;
+      transportCallReference: string;
 
     }
 

--- a/src/app/controller/services/jit/operations-event.service.ts
+++ b/src/app/controller/services/jit/operations-event.service.ts
@@ -1,8 +1,8 @@
-import {Injectable} from '@angular/core';
-import {HttpClient} from "@angular/common/http";
-import {Observable} from "rxjs";
-import {OperationsEvent} from "../../../model/jit/operations-event";
-import {Globals} from 'src/app/model/portCall/globals';
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { OperationsEvent } from "../../../model/jit/operations-event";
+import { Globals } from 'src/app/model/portCall/globals';
 import { TimestampInfo } from 'src/app/model/jit/timestampInfo';
 
 @Injectable({
@@ -20,8 +20,20 @@ export class OperationsEventService {
     this.EVENT_DELIVERY_STATUS_URL = globals.config.uiSupportBackendURL + "/unofficial/timestamp-info";
   }
 
-  getTimestampInfoForTransportCall = (transportCallId: string): Observable<TimestampInfo[]> => this.httpClient.get<TimestampInfo[]>(this.EVENT_DELIVERY_STATUS_URL + "?transportCallID=" + transportCallId + "&limit=" + this.LIMIT)
+  getTimestampInfoForTransportCall = (transportCallId: string, portCallPart?: string): Observable<TimestampInfo[]> => {
+    let httpParams = new HttpParams();
+    httpParams = httpParams.set('limit', this.LIMIT);
 
+    if (portCallPart) {
+      httpParams = httpParams.set('portCallPart', portCallPart);
+    }
+    if (transportCallId) {
+      httpParams = httpParams.set('transportCallID', transportCallId);
+    }
+    return this.httpClient.get<TimestampInfo[]>(this.EVENT_DELIVERY_STATUS_URL, {
+      params: httpParams
+    })
+  }
   getOperationsEventsByTransportCall = (transportCallId: string): Observable<OperationsEvent[]> => {
     const url = this.OPERATIONS_EVENT_URL + "?eventType=OPERATIONS" + "&transportCallID=" + transportCallId + '&sort=eventCreatedDateTime:DESC&limit=' + this.LIMIT;
     return this.httpClient.get<OperationsEvent[]>(url);
@@ -29,5 +41,5 @@ export class OperationsEventService {
 
   addOperationsEvent = (operationsEvent: OperationsEvent): Observable<OperationsEvent> => {
     return this.httpClient.post<OperationsEvent>(this.TIMESTAMPS_URL, operationsEvent);
-}
+  }
 }

--- a/src/app/model/jit/timestamp-definition.ts
+++ b/src/app/model/jit/timestamp-definition.ts
@@ -14,6 +14,7 @@ export interface TimestampDefinition {
   operationsEventTypeCode: OperationsEventTypeCode;
   portCallPhaseTypeCode: PortCallPhaseTypeCode;
   portCallServiceTypeCode: PortCallServiceTypeCode;
+  portCallPart?: string;
   facilityTypeCode: FacilityTypeCode;
   isBerthLocationNeeded: boolean;
   isPBPLocationNeeded: boolean;

--- a/src/app/model/jit/timestamp.ts
+++ b/src/app/model/jit/timestamp.ts
@@ -6,103 +6,105 @@ import { EventLocation } from "../eventLocation";
 import { VesselPosition } from "../vesselPosition";
 import { ModeOfTransport } from "../enums/modeOfTransport";
 import { PortCallServiceTypeCode } from "../enums/portCallServiceTypeCode";
-import {Port} from "../../model/portCall/port";
+import { Port } from "../../model/portCall/port";
 import { EventClassifierCode } from "./eventClassifierCode";
-import {NegotiationCycle} from "../portCall/negotiation-cycle";
-import {TimestampDefinition} from "./timestamp-definition";
-import {PortCallPhaseTypeCode} from "../enums/portCallPhaseTypeCode";
+import { NegotiationCycle } from "../portCall/negotiation-cycle";
+import { TimestampDefinition } from "./timestamp-definition";
+import { PortCallPhaseTypeCode } from "../enums/portCallPhaseTypeCode";
 
 export interface Timestamp {
-    publisher: Publisher;
-    publisherRole: PublisherRole;
-    vesselIMONumber: string;
-    UNLocationCode: string;
-        /**
-   * @deprecated
-   */
-    facilitySMDGCode?: string;
-    facilityTypeCode: FacilityTypeCode;
-    eventClassifierCode: EventClassifierCode;
-    operationsEventTypeCode: OperationsEventTypeCode;
-    eventLocation?: EventLocation;
-    vesselPosition?: VesselPosition;
-    modeOfTransport?: ModeOfTransport;
-    portCallPhaseTypeCode?: PortCallPhaseTypeCode;
-    portCallServiceTypeCode?: PortCallServiceTypeCode;
-    eventDateTime: Date | string;
-    carrierServiceCode?: string;
-    importVoyageNumber?: string;
-    exportVoyageNumber?: string;
-    portCallSequence?: string;
-    remark?: string;
-    delayReasonCode?: string;
-    eventDeliveryStatus?: string;
-    isLatestInCycle?: boolean;
-    negotiationCycle?: NegotiationCycle;
-    timestampDefinition?: TimestampDefinition;
-    response?: TimestampDefinition;
-    logOfTimestamp?: string | Date;
+  transportCallReference: string;
+  publisher: Publisher;
+  publisherRole: PublisherRole;
+  vesselIMONumber: string;
+  UNLocationCode: string;
+  facilityTypeCode: FacilityTypeCode;
+  eventClassifierCode: EventClassifierCode;
+  operationsEventTypeCode: OperationsEventTypeCode;
+  eventLocation?: EventLocation;
+  vesselPosition?: VesselPosition;
+  modeOfTransport?: ModeOfTransport;
+  portCallPhaseTypeCode?: PortCallPhaseTypeCode;
+  portCallServiceTypeCode?: PortCallServiceTypeCode;
+  eventDateTime: Date | string;
+  carrierServiceCode?: string;
+  importVoyageNumber?: string;
+  exportVoyageNumber?: string;
+  portCallSequence?: string;
+  remark?: string;
+  delayReasonCode?: string;
+  eventDeliveryStatus?: string;
+  isLatestInCycle?: boolean;
+  negotiationCycle?: NegotiationCycle;
+  timestampDefinition?: TimestampDefinition;
+  response?: TimestampDefinition;
+  logOfTimestamp?: string | Date;
+  
+  /**
+* @deprecated
+*/
+  facilitySMDGCode?: string;
 
-    /**
-   * @deprecated
-   */
-     facilityCode?: string;
+  /**
+ * @deprecated
+ */
+  facilityCode?: string;
   /**
    * @deprecated
    */
-   portPrevious?: Port | number;
-     /**
-   * @deprecated
-   */
-   portOfCall?: Port;
-     /**
-   * @deprecated
-   */
-   portNext?: Port | number;
+  portPrevious?: Port | number;
+  /**
+* @deprecated
+*/
+  portOfCall?: Port;
+  /**
+* @deprecated
+*/
+  portNext?: Port | number;
   /**
    * @deprecated
    */
-   locationType?: Port | number;
+  locationType?: Port | number;
   /**
    * @deprecated
    */
-   modifable?: Port | number;
-    /**
-   * @deprecated
-   */
-   modifiable?: boolean;
-     /**
-   * @deprecated
-   */
+  modifable?: Port | number;
+  /**
+ * @deprecated
+ */
+  modifiable?: boolean;
+  /**
+* @deprecated
+*/
   transportCallID?: string;
-    /**
-   * @deprecated
-   */
+  /**
+ * @deprecated
+ */
   messagingStatus?: string;
-    /**
-   * @deprecated
-   */
+  /**
+ * @deprecated
+ */
   messagingDetails?: string;
-    /**
-   * @deprecated
-   */
+  /**
+ * @deprecated
+ */
   outdatedMessage?: boolean;
-     /**
-   * @deprecated
-   */
-   uiReadByUser?:boolean;
-     /**
-   * @deprecated
-   */
-   sequenceColor?: string;
+  /**
+* @deprecated
+*/
+  uiReadByUser?: boolean;
+  /**
+* @deprecated
+*/
+  sequenceColor?: string;
 
-        /**
-   * @deprecated
-   */
-    eventTimestamp?: string | Date;
-
-
+  /**
+* @deprecated
+*/
+  eventTimestamp?: string | Date;
 
 
 
-  }
+
+
+}

--- a/src/app/model/jit/timestampInfo.ts
+++ b/src/app/model/jit/timestampInfo.ts
@@ -1,5 +1,9 @@
+import { OperationsEvent } from "./operations-event";
+import { TimestampDefinition } from "./timestamp-definition";
+
 export interface TimestampInfo {
     eventID: string;
     eventDeliveryStatus: string;
-    timestampDefinition: string;
+    operationsEventTO: OperationsEvent;
+    timestampDefinitionTO: TimestampDefinition;
 }

--- a/src/app/model/jit/transport-call.ts
+++ b/src/app/model/jit/transport-call.ts
@@ -1,7 +1,7 @@
-import {PortCallServiceTypeCode} from "../enums/portCallServiceTypeCode";
+import { PortCallServiceTypeCode } from "../enums/portCallServiceTypeCode";
 import { FacilityTypeCode } from "../enums/facilityTypeCodeOPR";
-import {FacilityCodeListProvider} from "../enums/facilityCodeListProvider";
-import {Vessel} from "../portCall/vessel";
+import { FacilityCodeListProvider } from "../enums/facilityCodeListProvider";
+import { Vessel } from "../portCall/vessel";
 import { Port } from "../portCall/port";
 import { EventLocation } from "../eventLocation";
 
@@ -11,7 +11,7 @@ export interface TransportCall {
   exportVoyageNumber?: string;
   importVoyageNumber?: string;
   portOfCall?: Port;
-  transportCallID: string;
+  transportCallReference: string;
   modeOfTransport: string;
   vesselIMONumber: string;
   vesselName: string;
@@ -28,4 +28,9 @@ export interface TransportCall {
   etaBerthDateTime?: Date;
   atdBerthDateTime?: Date;
   latestEventCreatedDateTime?: Date;
+
+  /**
+ * @deprecated
+ */
+  transportCallID?: string;
 }

--- a/src/app/view/timestamp-editor/timestamp-editor.component.ts
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.ts
@@ -73,7 +73,8 @@ export class TimestampEditorComponent implements OnInit {
     portOfCall: undefined,
     portPrevious: undefined,
     timestampDefinition: undefined,
-    transportCallID: ""
+    transportCallID: "",
+    transportCallReference:""
   };
 
 

--- a/src/app/view/timestamp-table/timestamp-table.component.html
+++ b/src/app/view/timestamp-table/timestamp-table.component.html
@@ -1,259 +1,219 @@
 <div *ngIf="progressing || !transportCallSelected" class="dummyContent">
-  <p-progressSpinner *ngIf="progressing"></p-progressSpinner>
-  <div *ngIf="!progressing && !transportCallSelected">
-    {{"general.table.placeHolder.label" | translate}}
-  </div>
+    <p-progressSpinner *ngIf="progressing"></p-progressSpinner>
+    <div *ngIf="!progressing && !transportCallSelected">
+        {{"general.table.placeHolder.label" | translate}}
+    </div>
 </div>
 <p-table *ngIf="!progressing && transportCallSelected" #dt [filterDelay]="0" [lazy]="false" [sortOrder]="1"
-         [value]="timestamps"
-         [globalFilterFields]="['timestampType','classifierCode','eventTypeCode','portOfCall','portPrevious', 'portNext']"
-         sortField="logOfTimestamp" [sortOrder]="-1" styleClass="p-datatable-sm">
-  <ng-template pTemplate="caption">
+    [value]="timestamps"
+    [globalFilterFields]="['timestampType','classifierCode','eventTypeCode','portOfCall','portPrevious', 'portNext']"
+    sortField="logOfTimestamp" [sortOrder]="-1" styleClass="p-datatable-sm">
+    <ng-template pTemplate="caption">
 
-    <div class="grid">
-      <div class="col">{{'general.table.header.timestamps.label' | translate}}</div>
-      <div class="col">
-        <p-dropdown id="negotiationCycle" styleClass="dropdown" [(ngModel)]="selectedNegotiationCycle" [options]="negotiationCycles"
-                    [filter]=true filterBy="label" appendTo="body" (onChange)="filterTimestamps()">
-        </p-dropdown>
-
-      </div>
-      <div class="col tableHeader">
-        <div class="tableHeader__buttons">
-          <p-button class="p-button-raised p-button-rounded tableHeader__add_button" (onClick)="openCreationDialog(null)"
-                    icon="pi pi-plus" pTooltip="{{ 'general.table.header.create.tooltip' | translate }}"
-                    tooltipPosition="left" type="button"
-                    tooltipStyleClass="ToolTipClass"></p-button>
+        <div class="grid">
+            <div class="col">{{'general.table.header.timestamps.label' | translate}}</div>
+            <div class="col">
+                <p-dropdown id="negotiationCycle" styleClass="dropdown" [(ngModel)]="selectedNegotiationCycle"
+                    [options]="negotiationCycles" [filter]=true filterBy="label" appendTo="body"
+                    (onChange)="filterTimestamps()">
+                </p-dropdown>
+                <p-dropdown id="portCallPart" styleClass="dropdown" [(ngModel)]="selectedPortCallPart"
+                    [options]="portCallParts" [filter]=true filterBy="label" appendTo="body"
+                    (onChange)="filterTimestampsByPortOfCallPart()">
+                </p-dropdown>
+            </div>
+            <div class="col tableHeader">
+                <div class="tableHeader__buttons">
+                    <p-button class="p-button-raised p-button-rounded tableHeader__add_button"
+                        (onClick)="openCreationDialog(null)" icon="pi pi-plus"
+                        pTooltip="{{ 'general.table.header.create.tooltip' | translate }}" tooltipPosition="left"
+                        type="button" tooltipStyleClass="ToolTipClass"></p-button>
+                </div>
+                <div class="tableHeader__buttons">
+                    <p-button (onClick)="refreshTimestamps()" class="p-button-raised p-button-rounded"
+                        icon="pi pi-refresh" pTooltip="{{ 'general.table.header.refresh' | translate }}"
+                        tooltipPosition="left" type="button" tooltipStyleClass="ToolTipClass"></p-button>
+                </div>
+            </div>
         </div>
-        <div class="tableHeader__buttons">
-          <p-button (onClick)="refreshTimestamps()" class="p-button-raised p-button-rounded"
-                    icon="pi pi-refresh" pTooltip="{{ 'general.table.header.refresh' | translate }}"
-                    tooltipPosition="left" type="button"
-                    tooltipStyleClass="ToolTipClass"></p-button>
-        </div>
-      </div>
-    </div>
-  </ng-template>
-  <ng-template pTemplate="header">
-    <tr>
-      <th style="width:3px"></th>
-      <th pTooltip="{{ 'general.table.header.vessel.tooltip' | translate }}"
-          style="width: 8%" tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.vessel.name' | translate }}
+    </ng-template>
+    <ng-template pTemplate="header">
+        <tr>
+            <th style="width:3px"></th>
+            <th pTooltip="{{ 'general.table.header.vessel.tooltip' | translate }}" style="width: 8%"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
+                {{ 'general.table.header.vessel.name' | translate }}
 
-      </th>
-      <th style="width: 7%"
-      pTooltip="{{ 'general.publisherRole.label' | translate }}"
-      tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
-    {{ 'general.publisherRole.label' | translate }}
+            </th>
+            <th style="width: 7%" pTooltip="{{ 'general.publisherRole.label' | translate }}" tooltipPosition="top"
+                tooltipStyleClass="ToolTipClass" class="timestampContent">
+                {{ 'general.publisherRole.label' | translate }}
 
-  </th>
-      <th pTooltip="{{ 'general.table.header.timestamp.tooltip' | translate }}"
-          style="width: 7%" tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.timestamp.label' | translate }}
+            </th>
+            <th pTooltip="{{ 'general.table.header.timestamp.tooltip' | translate }}" style="width: 7%"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
+                {{ 'general.table.header.timestamp.label' | translate }}
 
-      </th>
-      <th pTooltip="{{ 'general.table.header.logOfTimestamp.tooltip' | translate }}"
-          tooltipPosition="top" style="width: 15%" tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.logOfTimestamp.label' | translate }}
+            </th>
+            <th pTooltip="{{ 'general.table.header.logOfTimestamp.tooltip' | translate }}" tooltipPosition="top"
+                style="width: 15%" tooltipStyleClass="ToolTipClass" class="timestampContent">
+                {{ 'general.table.header.logOfTimestamp.label' | translate }}
 
-      </th>
-      <th pTooltip="{{ 'general.table.header.eventTimestamp.tooltip' | translate }}"
-          tooltipPosition="top" style="width: 15%" tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.eventTimestamp.label' | translate }}
+            </th>
+            <th pTooltip="{{ 'general.table.header.eventTimestamp.tooltip' | translate }}" tooltipPosition="top"
+                style="width: 15%" tooltipStyleClass="ToolTipClass" class="timestampContent">
+                {{ 'general.table.header.eventTimestamp.label' | translate }}
 
-      </th>
-        <!--
-      <th style="width: 8%" pSortableColumn="portPrevious"
-          pTooltip="{{ 'general.table.header.previousPort.tooltip' | translate }}" tooltipPosition="top"
-          tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.previousPort.label' | translate }}
-        <p-sortIcon field="portPrevious"></p-sortIcon>
-      </th>
-    -->
-      <th pTooltip="{{ 'general.table.header.portOfCall.tooltip' | translate }}"
-          style="width: 7%" tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.portOfCall.label' | translate }}
+            </th>
+            <th pTooltip="{{ 'general.table.header.portOfCall.tooltip' | translate }}" style="width: 7%"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
+                {{ 'general.table.header.portOfCall.label' | translate }}
 
-      </th>
-      <!--
-      <th style="width: 7%" pSortableColumn="portNext"
-          pTooltip="{{ 'general.table.header.nextPort.tooltip' | translate }}"
-          tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.nextPort.label' | translate }}
-        <p-sortIcon field="portNext"></p-sortIcon>
-      </th>
-      <th style="width: 6%" pSortableColumn="direction"
-          pTooltip="{{ 'general.table.header.direction.tooltip' | translate }}" tooltipPosition="top"
-          tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.direction.label' | translate }}
-        <p-sortIcon field="direction"></p-sortIcon>
-      </th>
-      -->
-      <th style="width: 7%"
-          pTooltip="{{ 'general.table.header.terminalId.tooltip' | translate }}"
-          tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
-        {{ 'general.table.header.terminalId.label' | translate }}
+            </th>
 
-      </th>
-      <th style="width: 10%" pTooltip="{{ 'general.table.header.locationName.tooltip' | translate }}"
-      tooltipPosition="top" tooltipStyleClass="ToolTipClass">{{ 'general.table.header.locationName.label' | translate }}</th>
-      <th style="width: 8%" pTooltip="{{ 'general.table.header.transportCallStatus.tooltip' | translate }}" tooltipPosition="top"
-          tooltipStyleClass="ToolTipClass" class="timestampContent">{{ 'general.table.header.transportCallStatus.label' | translate }}</th>
-      <th style="width: 12%" class="timestampContent" >
-      </th>
-    </tr>
-    <tr class="invisible">
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
+            <th style="width: 7%" pTooltip="{{ 'general.table.header.terminalId.tooltip' | translate }}"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">
+                {{ 'general.table.header.terminalId.label' | translate }}
 
-    </tr>
-  </ng-template>
-  <ng-template pTemplate="body" let-timestamp >
+            </th>
+            <th style="width: 10%" pTooltip="{{ 'general.table.header.locationName.tooltip' | translate }}"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass">{{ 'general.table.header.locationName.label' |
+                translate
+                }}</th>
+            <th style="width: 8%" pTooltip="{{ 'general.table.header.transportCallStatus.tooltip' | translate }}"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass" class="timestampContent">{{
+                'general.table.header.transportCallStatus.label' | translate }}</th>
+            <th style="width: 12%" class="timestampContent">
+            </th>
+        </tr>
+        <tr class="invisible">
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
 
-    <tr class="unreadTimestamp" [ngClass]="{'obsoleteTimestamp': timestamp.isLatestInCycle == false}">
-      <td pTooltip="Publisher: {{timestamp.publisher?.partyName}}
-        PublisherRole: {{timestamp.publisherRole}}" tooltipPosition="top"
-          tooltipStyleClass="ToolTipClass" style="width: 3px;"
-          [ngStyle]="{'background-color': timestamp.sequenceColor}"></td>
-      <td style="width: 8%"
-          [ngClass]="'timestampContent'">
-        <div>{{ (timestamp.vesselIMONumber | vesselIdToVessel: vessels).vesselName}}</div>
-        <div class="rowDetails">{{ (timestamp.vessel | vesselIdToVessel: vessels).serviceNameCode}}</div>
-      </td>
-      <td style="width: 8%"
-      [ngClass]="'timestampContent'">
-    <div>{{ (timestamp.publisherRole)}}</div>
-    <div class="rowDetails">{{ (timestamp.vessel | vesselIdToVessel: vessels).serviceNameCode}}</div>
-  </td>
-      <td style="width: 7%"
-          [ngClass]="'timestampContent'">
-        {{ timestamp.timestampDefinition?.timestampTypeName || 'UNKNOWN' }}
-      </td>
-      <td pTooltip ="UTC: {{(timestamp.logOfTimestamp | timestampToTimezone: timestamp.portOfCall)[1]}}"
-          style="width: 15%; opacity: 0.6;"
-          [ngClass]="'timestampContent'">
-        {{(timestamp.logOfTimestamp | timestampToTimezone: timestamp.portOfCall)[0]}}
-      </td>
-      <td pTooltip ="UTC: {{(timestamp.eventDateTime | timestampToTimezone: timestamp.portOfCall)[1]}}"
-          style="width: 15%"
-          [ngClass]="'timestampContent'">
-        {{(timestamp.eventDateTime | timestampToTimezone: timestamp.portOfCall)[0]}}
-      </td>
-        <!--
-      <td
-        [ngClass]="'timestampContent'">
-        <div
-          [ngClass]="'timestampContent'">{{ (timestamp.portPrevious | portIdToPort: ports).unLocode}}</div>
-        <div class="rowDetails">{{ (timestamp.portPrevious | portIdToPort: ports).name}}</div>
-      </td>
-       -->
-      <td
-        [ngClass]="'timestampContent'"
-        style="width: 8%">
-        <div
-          [ngClass]="'timestampContent'"> {{timestamp.portOfCall?.UNLocationCode}}</div>
-        <div class="rowDetails">{{timestamp.portOfCall?.unLocationName}}</div>
-      </td>
-      <td style="width: 6%"
-        [ngClass]="'timestampContent'">
-          <div pTooltip="{{timestamp.eventLocation?.facilityCode}}" tooltipPosition="top" tooltipStyleClass="ToolTipClass">
-            {{timestamp.eventLocation?.facilityCode}}</div>
+        </tr>
+    </ng-template>
+    <ng-template pTemplate="body" let-timestamp>
 
-        <div *ngIf="timestamp.eventLocation?.facilityCode == null">
-          <div *ngIf="timestamp.facilitySMDGCode != null"
-          pTooltip="{{timestamp.facilitySMDGCode}}" tooltipPosition="top" tooltipStyleClass="ToolTipClass">
-            {{timestamp.facilitySMDGCode}}
-          </div>
-          <div *ngIf="timestamp.facilitySMDGCode == null">
-          N/A
-          </div>
-        </div>
-      </td>
-      <td [ngClass]="'timestampContent'" style="width: 10%">{{ timestamp.eventLocation?.locationName }}</td>
-    <td *ngIf="isOutGoing(timestamp) && timestamp.eventDeliveryStatus === 'DELIVERY_FINISHED'" pTooltip="{{ 'general.table.header.eventDeliveryStatus.tooltip.grey' | translate }}" tooltipPosition="top"
-    tooltipStyleClass="ToolTipClass" [ngClass]="
-      {
-      'outgoingDelivered': timestamp.eventDeliveryStatus === 'DELIVERY_FINISHED'
-      }"
-      style="width: 4%">
-    </td>
-    <td *ngIf="isOutGoing(timestamp) && timestamp.eventDeliveryStatus === 'ATTEMPTED_DELIVERY'" pTooltip="{{ 'general.table.header.eventDeliveryStatus.tooltip.red' | translate }}" tooltipPosition="top"
-    tooltipStyleClass="ToolTipClass" [ngClass]="
-      {
-      'outgoingAttempted': timestamp.eventDeliveryStatus === 'ATTEMPTED_DELIVERY'
-      }"
-      style="width: 4%">
-    </td>
-    <td  *ngIf="isOutGoing(timestamp) && timestamp.eventDeliveryStatus === 'PENDING_DELIVERY'" pTooltip="{{ 'general.table.header.eventDeliveryStatus.tooltip.yellow' | translate }}" tooltipPosition="top"
-    tooltipStyleClass="ToolTipClass" [ngClass]="
-      {
-      'outgoingPending': timestamp.eventDeliveryStatus === 'PENDING_DELIVERY'
-      }"
-      style="width: 4%">
-    </td>
-                <!--this has been removed from the below td-->
-              <!-- [ngClass]="'unreadTimestamp' "-->
-      <td *ngIf="!isOutGoing(timestamp)" style="width: 4%"
-      class="ingoing" pTooltip="{{ 'general.table.header.eventDeliveryStatus.tooltip.green' | translate }}" tooltipPosition="top"
-    tooltipStyleClass="ToolTipClass">
-      <!--
-                <span *ngIf="timestamp.messageDirection != null" class="pi {{ timestamp.messageDirection == null ?
-                  '' :
-                  (timestamp.messageDirection == 'inbound' ?
-                        'pi-arrow-left' : 'pi-arrow-right'
-                  )
-              }}"
-                      pTooltip="{{ timestamp.messageDirection == null ?
-                  '' :
-                  (timestamp.messageDirection == 'inbound' ?
-                        ( 'general.direction.inbound' | translate ) : ( 'general.direction.outbound' | translate )
-                  )
-              }}"
-                      tooltipPosition="top" tooltipStyleClass="ToolTipClass">&nbsp;</span>  -->
+        <tr class="unreadTimestamp" [ngClass]="{'obsoleteTimestamp': timestamp.isLatestInCycle == false}">
+            <td pTooltip="Publisher: {{timestamp.publisher?.partyName}}
+          PublisherRole: {{timestamp.publisherRole}}" tooltipPosition="top" tooltipStyleClass="ToolTipClass"
+                style="width: 3px;" [ngStyle]="{'background-color': timestamp.sequenceColor}"></td>
+            <td style="width: 8%" [ngClass]="'timestampContent'">
+                <div>{{ (timestamp.vesselIMONumber | vesselIdToVessel: vessels).vesselName}}</div>
+                <div class="rowDetails">{{ (timestamp.vessel | vesselIdToVessel: vessels).serviceNameCode}}</div>
+            </td>
+            <td style="width: 8%" [ngClass]="'timestampContent'">
+                <div>{{ (timestamp.publisherRole)}}</div>
+                <div class="rowDetails">{{ (timestamp.vessel | vesselIdToVessel: vessels).serviceNameCode}}</div>
+            </td>
+            <td style="width: 7%" [ngClass]="'timestampContent'">
+                {{ timestamp.timestampDefinition?.timestampTypeName || 'UNKNOWN' }}
+            </td>
+            <td pTooltip="UTC: {{(timestamp.logOfTimestamp | timestampToTimezone: timestamp.portOfCall)[1]}}"
+                style="width: 15%; opacity: 0.6;" [ngClass]="'timestampContent'">
+                {{(timestamp.logOfTimestamp | timestampToTimezone: timestamp.portOfCall)[0]}}
+            </td>
+            <td pTooltip="UTC: {{(timestamp.eventDateTime | timestampToTimezone: timestamp.portOfCall)[1]}}"
+                style="width: 15%" [ngClass]="'timestampContent'">
+                {{(timestamp.eventDateTime | timestampToTimezone: timestamp.portOfCall)[0]}}
+            </td>
+            <td [ngClass]="'timestampContent'" style="width: 8%">
+                <div [ngClass]="'timestampContent'"> {{timestamp.portOfCall?.UNLocationCode}}</div>
+                <div class="rowDetails">{{timestamp.portOfCall?.unLocationName}}</div>
+            </td>
+            <td style="width: 6%" [ngClass]="'timestampContent'">
+                <div pTooltip="{{timestamp.eventLocation?.facilityCode}}" tooltipPosition="top"
+                    tooltipStyleClass="ToolTipClass">
+                    {{timestamp.eventLocation?.facilityCode}}</div>
 
+                <div *ngIf="timestamp.eventLocation?.facilityCode == null">
+                    <div *ngIf="timestamp.facilitySMDGCode != null" pTooltip="{{timestamp.facilitySMDGCode}}"
+                        tooltipPosition="top" tooltipStyleClass="ToolTipClass">
+                        {{timestamp.facilitySMDGCode}}
+                    </div>
+                    <div *ngIf="timestamp.facilitySMDGCode == null">
+                        N/A
+                    </div>
+                </div>
+            </td>
+            <td [ngClass]="'timestampContent'" style="width: 10%">{{ timestamp.eventLocation?.locationName }}</td>
+            <td *ngIf="isOutGoing(timestamp) && timestamp.eventDeliveryStatus === 'DELIVERY_FINISHED'"
+                pTooltip="{{ 'general.table.header.eventDeliveryStatus.tooltip.grey' | translate }}"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass" [ngClass]="
+        {
+        'outgoingDelivered': timestamp.eventDeliveryStatus === 'DELIVERY_FINISHED'
+        }" style="width: 4%">
+            </td>
+            <td *ngIf="isOutGoing(timestamp) && timestamp.eventDeliveryStatus === 'ATTEMPTED_DELIVERY'"
+                pTooltip="{{ 'general.table.header.eventDeliveryStatus.tooltip.red' | translate }}"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass" [ngClass]="
+        {
+        'outgoingAttempted': timestamp.eventDeliveryStatus === 'ATTEMPTED_DELIVERY'
+        }" style="width: 4%">
+            </td>
+            <td *ngIf="isOutGoing(timestamp) && timestamp.eventDeliveryStatus === 'PENDING_DELIVERY'"
+                pTooltip="{{ 'general.table.header.eventDeliveryStatus.tooltip.yellow' | translate }}"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass" [ngClass]="
+        {
+        'outgoingPending': timestamp.eventDeliveryStatus === 'PENDING_DELIVERY'
+        }" style="width: 4%">
+            </td>
+            <td *ngIf="!isOutGoing(timestamp)" style="width: 4%" class="ingoing"
+                pTooltip="{{ 'general.table.header.eventDeliveryStatus.tooltip.green' | translate }}"
+                tooltipPosition="top" tooltipStyleClass="ToolTipClass">
+            </td>
+            <td [ngClass]="'timestampContent'" style="width: 12%">
+                <div class="col tableHeader gridButtons">
+                    <div class="timestampContent__buttons dialogueBtn"
+                        *ngIf="timestamp.remark || timestamp.delayReasonCode">
+                        <p-button (onClick)="showComment(timestamp)" icon="pi pi-comment">
+                        </p-button>
+                    </div>
 
-      </td>
-      <td
-        [ngClass]="'timestampContent'"
-        style="width: 12%">
-        <div class="col tableHeader gridButtons">
-          <div class="timestampContent__buttons dialogueBtn" *ngIf="timestamp.remark || timestamp.delayReasonCode">
-            <p-button (onClick)="showComment(timestamp)" icon="pi pi-comment">
-            </p-button>
-          </div>
+                    <div class="timestampContent__buttons acceptBtn"
+                        *ngIf="timestamp.isLatestInCycle && isPrimary(timestamp) && timestamp.timestampDefinition?.acceptTimestampDefinition != null && !isOutGoing(timestamp)">
+                        <p-button icon="pi pi-check"
+                            pTooltip="{{ 'general.table.accept.tooltip' | translate }} {{timestamp.timestampDefinition?.acceptTimestampDefinitionEntity.timestampTypeName}}"
+                            tooltipPosition="left" tooltipStyleClass="ToolTipClass"
+                            (click)="openAcceptDialog(timestamp)"></p-button>
+                    </div>
 
-          <div class="timestampContent__buttons acceptBtn" *ngIf="timestamp.isLatestInCycle && isPrimary(timestamp) && timestamp.timestampDefinition?.acceptTimestampDefinition != null && !isOutGoing(timestamp)">
-            <p-button icon="pi pi-check" pTooltip="{{ 'general.table.accept.tooltip' | translate }} {{timestamp.timestampDefinition?.acceptTimestampDefinitionEntity.timestampTypeName}}"
-              tooltipPosition="left" tooltipStyleClass="ToolTipClass" (click)="openAcceptDialog(timestamp)"></p-button>
-          </div>
+                    <div class="timestampContent__buttons declineBtn"
+                        *ngIf="timestamp.isLatestInCycle && isPrimary(timestamp) && timestamp.timestampDefinition?.rejectTimestampDefinition != null && !isOutGoing(timestamp)">
+                        <p-button icon="pi pi-times"
+                            pTooltip="{{ 'general.table.decline.tooltip' | translate }}  {{timestamp.timestampDefinition?.rejectTimestampDefinitionEntity.timestampTypeName}}"
+                            tooltipPosition="left" tooltipStyleClass="ToolTipClass"
+                            (click)="openRejectDialog(timestamp)"></p-button>
+                    </div>
+                </div>
+                <div *ngIf="!isPrimary(timestamp) && !isOutGoing(timestamp)">FYI</div>
 
-          <div class="timestampContent__buttons declineBtn" *ngIf="timestamp.isLatestInCycle && isPrimary(timestamp) && timestamp.timestampDefinition?.rejectTimestampDefinition != null && !isOutGoing(timestamp)">
-            <p-button icon="pi pi-times" pTooltip="{{ 'general.table.decline.tooltip' | translate }}  {{timestamp.timestampDefinition?.rejectTimestampDefinitionEntity.timestampTypeName}}" tooltipPosition="left"
-              tooltipStyleClass="ToolTipClass" (click)="openRejectDialog(timestamp)"></p-button>
-          </div>
-        </div>
-    <div *ngIf="!isPrimary(timestamp) && !isOutGoing(timestamp)">FYI</div>
+            </td>
 
-      </td>
-
-    </tr>
-  </ng-template>
+        </tr>
+    </ng-template>
+    <ng-template pTemplate="emptymessage">
+        <tr>
+            <td [attr.colspan]=100>
+                <h4 style="text-align: center ">No results found</h4>
+            </td>
+        </tr>
+    </ng-template>
 </p-table>
 
-<p-confirmDialog key="deletetimestamp" header="Confirmation" icon="pi pi-exclamation-triangle"
-                 appendTo="body"></p-confirmDialog>
+<p-confirmDialog key="deletetimestamp" header="Confirmation" icon="pi pi-exclamation-triangle" appendTo="body">
+</p-confirmDialog>
 
 <p-toast key="TimestampToast" position="bottom-right"></p-toast>
 <p-toast key="TimestampAddSuccess" position="bottom-right"></p-toast>

--- a/src/app/view/transport-call-creator/transport-call-creator.component.ts
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.ts
@@ -243,6 +243,7 @@ export class TransportCallCreatorComponent implements OnInit {
   async saveNewTransportCall() {
     this.creationProgress = true;
     let transportCall: TransportCall = new class implements TransportCall {
+      transportCallReference: string;
       UNLocationCode: string;
       carrierServiceCode: string;
       carrierVoyageNumber: string;
@@ -299,6 +300,7 @@ export class TransportCallCreatorComponent implements OnInit {
       publisherRole: PublisherRole;
       vesselIMONumber: string;
       delayReasonCode: string;
+      transportCallReference: string;
       timestampDefinition: TimestampDefinition;
     }
 

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -18,7 +18,7 @@
     },
     "identifyingCodes": [
       {
-        "codeListResponsibleAgencyCode": "306",
+        "DCSAResponsibleAgencyCode": "SMDG",
         "partyCode": "MSK"
       }
     ],

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -107,18 +107,18 @@
           "detail": "Successfully accepted timestamp",
           "summary": "Success!"
         }
+      },
+      "Rejecteditor": {
+        "label": "Reject Timestamp",
+        "failure": {
+          "summary": "Error!",
+          "detail": "Error while rejecting timestamp: "
         },
-        "Rejecteditor": {
-          "label": "Reject Timestamp",
-          "failure": {
-            "summary": "Error!",
-            "detail": "Error while rejecting timestamp: "
-          },
-          "success": {
-            "detail": "Successfully rejected timestamp",
-            "summary": "Success!"
-          }
-        },
+        "success": {
+          "detail": "Successfully rejected timestamp",
+          "summary": "Success!"
+        }
+      },
       "label": "Save"
     },
     "table": {
@@ -208,7 +208,7 @@
         },
         "timestamp": {
           "label": "Timestamp",
-          "acceptlabel":"Responding with timestamp type",
+          "acceptlabel": "Responding with timestamp type",
           "tooltip": "An estimated, requested, planned or actual timestamp of an event."
         },
         "timestamps": {
@@ -223,7 +223,7 @@
           "label": "Delivery status",
           "tooltip": "The current delivery status of the timestamp"
         },
-        "locationName":{
+        "locationName": {
           "label": "Location name",
           "tooltip": "Location name"
         }
@@ -232,6 +232,9 @@
     },
     "negotiationCycle": {
       "select": "Select negotiation cycle"
+    },
+    "portCallParts": {
+      "select": "Select port of call Part"
     },
     "terminal": {
       "label": "Terminal",


### PR DESCRIPTION
- Align type names with field names in backend (As needed for the scope of this issue)
- deprecate transportCallID
-  add portcallPart filter
- show warning if no timestamps match filter 