### PR TITLE
Partly align entities with JIT-1.2 spec & more

### DIFF
--- a/src/app/controller/pipes/operations-event-to-timestamp.pipe.ts
+++ b/src/app/controller/pipes/operations-event-to-timestamp.pipe.ts
@@ -10,14 +10,14 @@ import { PublisherRole } from 'src/app/model/enums/publisherRole';
 import { FacilityTypeCode } from 'src/app/model/enums/facilityTypeCodeOPR';
 import { EventClassifierCode } from 'src/app/model/jit/eventClassifierCode';
 import { OperationsEventTypeCode } from 'src/app/model/enums/operationsEventTypeCode';
-import { TimestampDefinition } from "../../model/jit/timestamp-definition";
+import { timestampDefinitionTO } from "../../model/jit/timestamp-definition";
 
 @Pipe({
   name: 'operationsEventEventToTimestamp'
 })
 export class OperationsEventToTimestampPipe implements PipeTransform {
 
-  transform(operationsEvent: OperationsEvent, timestampDefinitions: Map<string, TimestampDefinition>): Timestamp {
+  transform(operationsEvent: OperationsEvent, timestampDefinitions: Map<string, timestampDefinitionTO>): Timestamp {
     let timestamp: Timestamp;
     timestamp = new class implements Timestamp {
       publisher: Publisher;
@@ -43,14 +43,15 @@ export class OperationsEventToTimestampPipe implements PipeTransform {
       portNext: Port | number;
       portOfCall: Port;
       portPrevious: Port | number;
-      response: TimestampDefinition;
+      response: timestampDefinitionTO;
       sequenceColor: string;
       terminal: Terminal | number;
-      timestampDefinition: TimestampDefinition;
+      timestampDefinitionTO: timestampDefinitionTO;
       transportCallID: string;
       uiReadByUser: boolean;
       vessel: number | Vessel;
       transportCallReference: string;
+      carrierVoyageNumber: string;
     }
 
     timestamp.publisher = operationsEvent.publisher;
@@ -63,6 +64,7 @@ export class OperationsEventToTimestampPipe implements PipeTransform {
     timestamp.operationsEventTypeCode = operationsEvent.operationsEventTypeCode;
     timestamp.eventDateTime = operationsEvent.eventDateTime;
     timestamp.portCallServiceTypeCode = operationsEvent.portCallServiceTypeCode;
+    timestamp.portCallPhaseTypeCode = operationsEvent.portCallPhaseTypeCode;
     timestamp.facilityTypeCode = operationsEvent.facilityTypeCode;
     if (operationsEvent.eventLocation?.facilityCodeListProvider == 'SMDG') {
       timestamp.facilitySMDGCode = operationsEvent.eventLocation?.facilityCode;
@@ -72,7 +74,7 @@ export class OperationsEventToTimestampPipe implements PipeTransform {
     timestamp.delayReasonCode = operationsEvent.delayReasonCode;
     timestamp.eventDeliveryStatus = operationsEvent.eventDeliveryStatus;
     // Extras   
-    timestamp.timestampDefinition = timestampDefinitions?.get(operationsEvent.timestampDefinitionID)
+    timestamp.timestampDefinitionTO = timestampDefinitions?.get(operationsEvent.timestampDefinitionID)
     timestamp.logOfTimestamp = operationsEvent.eventCreatedDateTime;
     timestamp.transportCallID = operationsEvent.transportCall.transportCallID;
     timestamp.transportCallReference = operationsEvent?.transportCall?.transportCallReference;

--- a/src/app/controller/pipes/operations-events-to-timestamps.pipe.ts
+++ b/src/app/controller/pipes/operations-events-to-timestamps.pipe.ts
@@ -2,14 +2,14 @@ import { Pipe, PipeTransform } from '@angular/core';
 import {OperationsEvent} from "../../model/jit/operations-event";
 import {OperationsEventToTimestampPipe} from "./operations-event-to-timestamp.pipe";
 import { Timestamp } from 'src/app/model/jit/timestamp';
-import {TimestampDefinition} from "../../model/jit/timestamp-definition";
+import {timestampDefinitionTO} from "../../model/jit/timestamp-definition";
 
 @Pipe({
   name: 'transportEventsToTimestamps'
 })
 export class OperationsEventsToTimestampsPipe implements PipeTransform {
 
-  transform(operationsEvent: OperationsEvent[], timestampDefinitions: Map<string, TimestampDefinition>): Timestamp[] {
+  transform(operationsEvent: OperationsEvent[], timestampDefinitions: Map<string, timestampDefinitionTO>): Timestamp[] {
     let timestamps: Timestamp[] = [];
     const pipe = new OperationsEventToTimestampPipe();
     for (let event of operationsEvent) {

--- a/src/app/controller/pipes/timestamp-to-standardized-timestamp.ts
+++ b/src/app/controller/pipes/timestamp-to-standardized-timestamp.ts
@@ -33,27 +33,34 @@ export class TimestampToStandardizedtTimestampPipe implements PipeTransform {
       transportCall: TransportCall;
       identifyingCodes?: identifyingCodes;
       transportCallReference: string;
+      carrierVoyageNumber: string;
 
     }
 
     newTimestamp.publisher = configurations.publisher;
-    newTimestamp.publisherRole = portcallTimestamp.timestampDefinition.publisherRole;
+    newTimestamp.publisherRole = portcallTimestamp.timestampDefinitionTO.publisherRole;
     newTimestamp.vesselIMONumber = portcallTimestamp.vesselIMONumber;
-    newTimestamp.UNLocationCode = portcallTimestamp.UNLocationCode;
-    newTimestamp.facilitySMDGCode = portcallTimestamp.facilitySMDGCode;
-    newTimestamp.facilityTypeCode = portcallTimestamp.timestampDefinition.facilityTypeCode;
-    newTimestamp.eventClassifierCode = portcallTimestamp.timestampDefinition.eventClassifierCode;
-    newTimestamp.operationsEventTypeCode = portcallTimestamp.timestampDefinition.operationsEventTypeCode;
-    newTimestamp.eventLocation = portcallTimestamp.eventLocation;
-    newTimestamp.vesselPosition = portcallTimestamp.vesselPosition;
-    newTimestamp.modeOfTransport = portcallTimestamp.modeOfTransport;
-    newTimestamp.portCallServiceTypeCode = portcallTimestamp.timestampDefinition.portCallServiceTypeCode;
-    newTimestamp.portCallPhaseTypeCode = portcallTimestamp.timestampDefinition.portCallPhaseTypeCode;
-    newTimestamp.eventDateTime = portcallTimestamp.eventDateTime;
+    newTimestamp.vessel = portcallTimestamp.vessel;
+    newTimestamp.carrierServiceCode = portcallTimestamp.carrierServiceCode;
     newTimestamp.exportVoyageNumber = portcallTimestamp.exportVoyageNumber;
     newTimestamp.importVoyageNumber = portcallTimestamp.importVoyageNumber;
-    newTimestamp.carrierServiceCode = portcallTimestamp.carrierServiceCode;
+    newTimestamp.portVisitReference = portcallTimestamp.portVisitReference;
+    newTimestamp.carrierExportVoyageNumber = portcallTimestamp.carrierExportVoyageNumber;
+    newTimestamp.carrierImportVoyageNumber = portcallTimestamp.carrierImportVoyageNumber;
+    newTimestamp.transportCallSequenceNumber = portcallTimestamp.transportCallSequenceNumber
+    newTimestamp.vesselPosition = portcallTimestamp.vesselPosition;
+    newTimestamp.UNLocationCode = portcallTimestamp.UNLocationCode;
+    newTimestamp.facilitySMDGCode = portcallTimestamp.facilitySMDGCode;
+    newTimestamp.facilityTypeCode = portcallTimestamp.timestampDefinitionTO.facilityTypeCode;
+    newTimestamp.eventLocation = portcallTimestamp.eventLocation;
+    newTimestamp.eventClassifierCode = portcallTimestamp.timestampDefinitionTO.eventClassifierCode;
+    newTimestamp.operationsEventTypeCode = portcallTimestamp.timestampDefinitionTO.operationsEventTypeCode;
+    newTimestamp.modeOfTransport = portcallTimestamp.modeOfTransport;
+    newTimestamp.portCallServiceTypeCode = portcallTimestamp.timestampDefinitionTO.portCallServiceTypeCode;
+    newTimestamp.portCallPhaseTypeCode = portcallTimestamp.timestampDefinitionTO.portCallPhaseTypeCode;
+    newTimestamp.eventDateTime = portcallTimestamp.eventDateTime;
     newTimestamp.portCallSequence = portcallTimestamp.portCallSequence;
+    newTimestamp.carrierVoyageNumber = portcallTimestamp.carrierVoyageNumber;
     newTimestamp.remark = portcallTimestamp.remark;
     newTimestamp.delayReasonCode = portcallTimestamp.delayReasonCode;
 

--- a/src/app/controller/services/base/negotiation-cycle.service.ts
+++ b/src/app/controller/services/base/negotiation-cycle.service.ts
@@ -27,7 +27,7 @@ export class NegotiationCycleService {
   getNegotiationCycles = (): Observable<NegotiationCycle[]> => this.httpClient.get<NegotiationCycle[]>(this.NEGOTIATION_CYCLE_BACKEND);
 
   enrichTimestampWithNegotiationCycle(timestamp: Timestamp): NegotiationCycle {
-    const negotiationCycleKey: string = timestamp.timestampDefinition.negotiationCycle;
+    const negotiationCycleKey: string = timestamp.timestampDefinitionTO.negotiationCycle;
     let negotiationCycle = this.negotiationCycles.get(negotiationCycleKey);
     if (!negotiationCycle) {
       negotiationCycle = new class implements NegotiationCycle {

--- a/src/app/controller/services/base/timestamp-definition.service.ts
+++ b/src/app/controller/services/base/timestamp-definition.service.ts
@@ -2,13 +2,13 @@ import {Injectable} from '@angular/core';
 import {HttpClient, HttpParams} from "@angular/common/http";
 import {Observable, of} from "rxjs";
 import {Globals} from "../../../model/portCall/globals";
-import {TimestampDefinition} from "../../../model/jit/timestamp-definition";
+import {timestampDefinitionTO} from "../../../model/jit/timestamp-definition";
 import {map} from 'rxjs/operators';
 
-function asMap(timestampDefinitions: TimestampDefinition[]): Map<string, TimestampDefinition> {
-  let map = new Map<string, TimestampDefinition>()
-  for (let timestampDefinition of timestampDefinitions) {
-    map.set(timestampDefinition.id, timestampDefinition);
+function asMap(timestampDefinitions: timestampDefinitionTO[]): Map<string, timestampDefinitionTO> {
+  let map = new Map<string, timestampDefinitionTO>()
+  for (let timestampDefinitionTO of timestampDefinitions) {
+    map.set(timestampDefinitionTO.id, timestampDefinitionTO);
   }
   return map;
 }
@@ -19,28 +19,28 @@ function asMap(timestampDefinitions: TimestampDefinition[]): Map<string, Timesta
 export class TimestampDefinitionService {
   private readonly TIMESTAMP_DEFINITION_BACKEND: string;
   // the timestamps are not likely to change during a work session.
-  private definitionCache: TimestampDefinition[] = [];
+  private definitionCache: timestampDefinitionTO[] = [];
 
   constructor(private httpClient: HttpClient,
               private globals: Globals) {
     this.TIMESTAMP_DEFINITION_BACKEND = globals.config.uiSupportBackendURL + '/unofficial/timestamp-definitions';
   }
 
-  getTimestampDefinitions(): Observable<TimestampDefinition[]> {
+  getTimestampDefinitions(): Observable<timestampDefinitionTO[]> {
     if (this.definitionCache.length == 0) {
       let httpParams = new HttpParams();
       httpParams = httpParams.set("canonicalTimestampDefinition", "NULL").set("limit", "250");
-      return this.httpClient.get<TimestampDefinition[]>(this.TIMESTAMP_DEFINITION_BACKEND, {params: httpParams})
+      return this.httpClient.get<timestampDefinitionTO[]>(this.TIMESTAMP_DEFINITION_BACKEND, {params: httpParams})
         .pipe(
           map(definitions => {
             let table = asMap(definitions);
-            // Set up links between "TimestampDefinition"s.
-            for (let timestampDefinition of definitions) {
-              if (timestampDefinition.acceptTimestampDefinition) {
-                timestampDefinition.acceptTimestampDefinitionEntity = table.get(timestampDefinition.acceptTimestampDefinition)
+            // Set up links between "timestampDefinitionTO"s.
+            for (let timestampDefinitionTO of definitions) {
+              if (timestampDefinitionTO.acceptTimestampDefinition) {
+                timestampDefinitionTO.acceptTimestampDefinitionEntity = table.get(timestampDefinitionTO.acceptTimestampDefinition)
               }
-              if (timestampDefinition.rejectTimestampDefinition) {
-                timestampDefinition.rejectTimestampDefinitionEntity = table.get(timestampDefinition.rejectTimestampDefinition)
+              if (timestampDefinitionTO.rejectTimestampDefinition) {
+                timestampDefinitionTO.rejectTimestampDefinitionEntity = table.get(timestampDefinitionTO.rejectTimestampDefinition)
               }
             }
             return definitions;
@@ -53,7 +53,7 @@ export class TimestampDefinitionService {
 
 
 
-  getTimestampDefinitionsMap(): Observable<Map<string, TimestampDefinition>> {
+  getTimestampDefinitionsMap(): Observable<Map<string, timestampDefinitionTO>> {
     return this.getTimestampDefinitions().pipe(
       map(timestampDefinitions => {
         return asMap(timestampDefinitions);

--- a/src/app/controller/services/jit/transport-call.service.ts
+++ b/src/app/controller/services/jit/transport-call.service.ts
@@ -40,7 +40,7 @@ export class TransportCallService {
     }).pipe(
       mergeMap((transportCalls => {
         return from(transportCalls).pipe(
-          map(this.extractVesselAttributes),
+           map(this.extractVesselAttributes),
           map((transportCall) => {
             if (transportCall.UNLocationCode == null) {
                 transportCall.UNLocationCode = transportCall.location?.UNLocationCode;
@@ -67,7 +67,7 @@ export class TransportCallService {
 
 
   private extractVesselAttributes(transportCall: TransportCall) {
-    if (transportCall['vessel'] === undefined) {
+    if (transportCall['vessel'] === undefined || transportCall['vessel'] === null) {
       transportCall.vesselName = null;
       transportCall.vesselIMONumber = null;
     } else {

--- a/src/app/controller/services/mapping/timestamp-mapping.service.ts
+++ b/src/app/controller/services/mapping/timestamp-mapping.service.ts
@@ -9,7 +9,7 @@ import { Timestamp } from "../../../model/jit/timestamp";
 import { TimestampService } from "../jit/timestamps.service";
 import { TimestampToStandardizedtTimestampPipe } from '../../pipes/timestamp-to-standardized-timestamp';
 import { NegotiationCycleService } from "../base/negotiation-cycle.service";
-import { TimestampDefinition } from "../../../model/jit/timestamp-definition";
+import { timestampDefinitionTO } from "../../../model/jit/timestamp-definition";
 import { TimestampDefinitionService } from "../base/timestamp-definition.service";
 
 @Injectable({
@@ -42,14 +42,17 @@ export class TimestampMappingService {
       mergeMap(timestampInfos =>
         this.timestampDefinitionService.getTimestampDefinitionsMap().pipe(
           map(timestampDefinitionsMap => {
-            const operationEvents = timestampInfos.map(timestampInfo => timestampInfo.operationsEventTO);
+
+            const operationEvents = timestampInfos.map(timestampInfo =>{ 
+              timestampInfo.operationsEventTO.timestampDefinitionID = timestampInfo.timestampDefinitionTO.id;
+              return timestampInfo.operationsEventTO});
             return this.operationsEventsToTimestampsPipe.transform(operationEvents, timestampDefinitionsMap);
           }),
           map(timestamps => {
             this.mapTransportCallToTimestamps(timestamps, transportCall);
             let set = new Set()
             for (let timestamp of timestamps) {
-              if (timestamp.timestampDefinition) {
+              if (timestamp.timestampDefinitionTO) {
                 let negotiationCycle = this.negotiationCycleService.enrichTimestampWithNegotiationCycle(timestamp);
                 const negotiationCycleKey = negotiationCycle.cycleKey;
                 timestamp.isLatestInCycle = !set.has(negotiationCycleKey)
@@ -79,7 +82,7 @@ export class TimestampMappingService {
     }
   }
 
-  getLocationNameOptionLabel(timestampType: TimestampDefinition): string {
+  getLocationNameOptionLabel(timestampType: timestampDefinitionTO): string {
     if (timestampType?.isBerthLocationNeeded) {
       return this.locationNameBerth;
     }

--- a/src/app/model/jit/operations-event.ts
+++ b/src/app/model/jit/operations-event.ts
@@ -8,6 +8,7 @@ import { Publisher } from "../publisher";
 import { FacilityTypeCode } from "../enums/facilityTypeCodeOPR";
 import { EventLocation } from "../eventLocation";
 import { VesselPosition } from "../vesselPosition";
+import { PortCallPhaseTypeCode } from "../enums/portCallPhaseTypeCode";
 
 export interface OperationsEvent {
   eventID?: string;
@@ -30,5 +31,6 @@ export interface OperationsEvent {
   timestampDefinitionID?: string;
   facilityCode: string;
   vesselPosition?: VesselPosition;
+  portCallPhaseTypeCode?: PortCallPhaseTypeCode
 
 }

--- a/src/app/model/jit/timestamp-definition.ts
+++ b/src/app/model/jit/timestamp-definition.ts
@@ -5,7 +5,7 @@ import {PortCallPhaseTypeCode} from "../enums/portCallPhaseTypeCode";
 import {PortCallServiceTypeCode} from "../enums/portCallServiceTypeCode";
 import {FacilityTypeCode} from "../enums/facilityTypeCodeOPR";
 
-export interface TimestampDefinition {
+export interface timestampDefinitionTO {
   id: string;
   timestampTypeName: string;
   publisherRole: PublisherRole;
@@ -24,7 +24,7 @@ export interface TimestampDefinition {
   providedInStandard: string;
 
   acceptTimestampDefinition: string;
-  acceptTimestampDefinitionEntity?: TimestampDefinition;
+  acceptTimestampDefinitionEntity?: timestampDefinitionTO;
   rejectTimestampDefinition: string;
-  rejectTimestampDefinitionEntity?: TimestampDefinition;
+  rejectTimestampDefinitionEntity?: timestampDefinitionTO;
 }

--- a/src/app/model/jit/timestamp.ts
+++ b/src/app/model/jit/timestamp.ts
@@ -9,37 +9,62 @@ import { PortCallServiceTypeCode } from "../enums/portCallServiceTypeCode";
 import { Port } from "../../model/portCall/port";
 import { EventClassifierCode } from "./eventClassifierCode";
 import { NegotiationCycle } from "../portCall/negotiation-cycle";
-import { TimestampDefinition } from "./timestamp-definition";
+import { timestampDefinitionTO } from "./timestamp-definition";
 import { PortCallPhaseTypeCode } from "../enums/portCallPhaseTypeCode";
+import { Vessel } from "../portCall/vessel";
 
 export interface Timestamp {
   transportCallReference: string;
   publisher: Publisher;
   publisherRole: PublisherRole;
-  vesselIMONumber: string;
   UNLocationCode: string;
   facilityTypeCode: FacilityTypeCode;
   eventClassifierCode: EventClassifierCode;
   operationsEventTypeCode: OperationsEventTypeCode;
   eventLocation?: EventLocation;
   vesselPosition?: VesselPosition;
-  modeOfTransport?: ModeOfTransport;
   portCallPhaseTypeCode?: PortCallPhaseTypeCode;
   portCallServiceTypeCode?: PortCallServiceTypeCode;
   eventDateTime: Date | string;
   carrierServiceCode?: string;
-  importVoyageNumber?: string;
-  exportVoyageNumber?: string;
   portCallSequence?: string;
   remark?: string;
   delayReasonCode?: string;
   eventDeliveryStatus?: string;
   isLatestInCycle?: boolean;
   negotiationCycle?: NegotiationCycle;
-  timestampDefinition?: TimestampDefinition;
-  response?: TimestampDefinition;
+  timestampDefinitionTO?: timestampDefinitionTO;
+  response?: timestampDefinitionTO;
   logOfTimestamp?: string | Date;
-  
+  carrierExportVoyageNumber?: string;
+  carrierImportVoyageNumber?: string;
+  vessel?:  number | Vessel;
+  portVisitReference?: string;
+  milesToDestinationPort?: number;
+  transportCallSequenceNumber?: number;
+
+  /**
+* @deprecated
+*/
+  modeOfTransport?: ModeOfTransport;
+  /**
+  * @deprecated
+  */
+  carrierVoyageNumber: string;
+
+  /**
+* @deprecated
+*/
+  importVoyageNumber?: string;
+  /**
+* @deprecated
+*/
+  exportVoyageNumber?: string;
+
+  /**
+* @deprecated
+*/
+  vesselIMONumber: string;
   /**
 * @deprecated
 */

--- a/src/app/model/jit/timestampInfo.ts
+++ b/src/app/model/jit/timestampInfo.ts
@@ -1,9 +1,9 @@
 import { OperationsEvent } from "./operations-event";
-import { TimestampDefinition } from "./timestamp-definition";
+import { timestampDefinitionTO } from "./timestamp-definition";
 
 export interface TimestampInfo {
     eventID: string;
     eventDeliveryStatus: string;
     operationsEventTO: OperationsEvent;
-    timestampDefinitionTO: TimestampDefinition;
+    timestampDefinitionTO: timestampDefinitionTO;
 }

--- a/src/app/model/portCall/vessel.ts
+++ b/src/app/model/portCall/vessel.ts
@@ -1,21 +1,21 @@
-import {vesselOperatorCarrierCodeListProvider} from "../enums/vesselOperatorCarrierCodeListProvider";
+import { vesselOperatorCarrierCodeListProvider } from "../enums/vesselOperatorCarrierCodeListProvider";
 
 export interface Vessel {
-  id: string;                         // id
-  vesselIMONumber: string;            // number; (7)
-  vesselName: string;                 // name: string; (35)
-  vesselFlag: string;                 // (2)
-  vesselCallSignNumber: string;       // (10)
-  vesselOperatorCarrierCode: string,
-  vesselOperatorCarrierCodeListProvider: vesselOperatorCarrierCodeListProvider,
+  id?: string;                         // id
+  vesselName?: string;                 // name: string; (35)
+  vesselFlag?: string;                 // (2)
+  vesselCallSignNumber?: string;       // (10)
+  vesselOperatorCarrierCode?: string,
+  vesselOperatorCarrierCodeListProvider?: vesselOperatorCarrierCodeListProvider,
   dimensionUnit?: string;
-  type: string;
-  width: number;
-  length: number;
-
-    /**
-   * @deprecated
-   */
+  type?: string;
+  width?: number;
+  length?: number;
+  vesselIMONumber: string;            // number; (7)
+  
+  /**
+ * @deprecated
+ */
   vesselOperatorCarrierID?: string;    // UUID
   /**
    * @deprecated

--- a/src/app/model/vesselPosition.ts
+++ b/src/app/model/vesselPosition.ts
@@ -1,5 +1,5 @@
-export interface VesselPosition { 
-    latitude: string;
-    longitude: string;
-  }
-  
+export interface VesselPosition {
+  locationName?: string;
+  latitude: string;
+  longitude: string;
+}

--- a/src/app/view/timestamp-accept-editor/timestamp-accept-editor.component.html
+++ b/src/app/view/timestamp-accept-editor/timestamp-accept-editor.component.html
@@ -41,7 +41,7 @@
         <!-- Placeholder for additional information when rejecting timestamp -->
         <label class="label-compressed" for="eventtimestamp">{{'general.table.header.timestamp.acceptlabel' |
           translate }}</label>
-        <span style="font-weight: bold;">{{": " + responseTimestamp.timestampDefinition.timestampTypeName}}</span>
+        <span style="font-weight: bold;">{{": " + responseTimestamp.timestampDefinitionTO.timestampTypeName}}</span>
       </div>
     </div>
   </p-card>

--- a/src/app/view/timestamp-accept-editor/timestamp-accept-editor.component.ts
+++ b/src/app/view/timestamp-accept-editor/timestamp-accept-editor.component.ts
@@ -14,7 +14,7 @@ import {EventLocation} from "../../model/eventLocation";
 import {VesselPosition} from "../../model/vesselPosition";
 import {Terminal} from 'src/app/model/portCall/terminal';
 import {TerminalService} from 'src/app/controller/services/base/terminal.service';
-import {TimestampDefinition} from "../../model/jit/timestamp-definition";
+import {timestampDefinitionTO} from "../../model/jit/timestamp-definition";
 import { DateToUtcPipe } from 'src/app/controller/pipes/date-to-utc.pipe';
 
 
@@ -47,7 +47,7 @@ export class TimestampAcceptEditorComponent implements OnInit {
   }
   VesselPositionLabel:boolean;
   transportCall: TransportCall;
-  timestampDefinitions: TimestampDefinition[] = [];
+  timestampDefinitions: timestampDefinitionTO[] = [];
   timestampTypes: SelectItem[] = [];
   delayCodeOptions: SelectItem[] = [];
   delayCodes: DelayCode[];
@@ -87,17 +87,17 @@ export class TimestampAcceptEditorComponent implements OnInit {
 
   showVesselPosition(): boolean {
     if (!this.globals.config.enableVesselPositions) return false;
-    this.VesselPositionLabel = this.responseTimestamp.timestampDefinition.isVesselPositionNeeded;
+    this.VesselPositionLabel = this.responseTimestamp.timestampDefinitionTO.isVesselPositionNeeded;
     return this.VesselPositionLabel ?? false;
   }
 
   showLocationNameOption(): boolean {
-    this.locationNameLabel = this.timestampMappingService.getLocationNameOptionLabel(this.responseTimestamp.timestampDefinition);
+    this.locationNameLabel = this.timestampMappingService.getLocationNameOptionLabel(this.responseTimestamp.timestampDefinitionTO);
     return this.locationNameLabel !== undefined;
   }
 
   showTerminalOption(): boolean {
-    return this.responseTimestamp.timestampDefinition.isTerminalNeeded ?? false;
+    return this.responseTimestamp.timestampDefinitionTO.isTerminalNeeded ?? false;
   }
 
   private updateDelayCodeOptions() {
@@ -145,7 +145,7 @@ export class TimestampAcceptEditorComponent implements OnInit {
     this.responseTimestamp.vesselPosition = null;
     this.responseTimestamp.facilitySMDGCode = null;
 
-    if(this.responseTimestamp.timestampDefinition.isTerminalNeeded){
+    if(this.responseTimestamp.timestampDefinitionTO.isTerminalNeeded){
       // Selected terminal is set (Whether inhereted or new).
       this.responseTimestamp.facilitySMDGCode = (this.terminalSelected?.facilitySMDGCode ? this.terminalSelected?.facilitySMDGCode : null);
     }

--- a/src/app/view/timestamp-editor/timestamp-editor.component.ts
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.ts
@@ -16,7 +16,7 @@ import {VesselPosition} from "../../model/vesselPosition";
 import {Terminal} from 'src/app/model/portCall/terminal';
 import {TerminalService} from 'src/app/controller/services/base/terminal.service';
 import {TimestampDefinitionService} from "../../controller/services/base/timestamp-definition.service";
-import {TimestampDefinition} from "../../model/jit/timestamp-definition";
+import {timestampDefinitionTO} from "../../model/jit/timestamp-definition";
 
 
 @Component({
@@ -39,7 +39,7 @@ export class TimestampEditorComponent implements OnInit {
   timestamps: Timestamp[];
   eventTimestampDate: Date;
   eventTimestampTime: string;
-  timestampSelected: TimestampDefinition;
+  timestampSelected: timestampDefinitionTO;
   creationProgress: boolean = false;
   locationNameLabel: string;
   locationName: string;
@@ -49,7 +49,7 @@ export class TimestampEditorComponent implements OnInit {
     longitude: string;
   }
   transportCall: TransportCall;
-  timestampDefinitions: TimestampDefinition[] = [];
+  timestampDefinitions: timestampDefinitionTO[] = [];
   timestampTypes: SelectItem[] = [];
   delayCodeOptions: SelectItem[] = [];
   delayCodes: DelayCode[];
@@ -72,9 +72,10 @@ export class TimestampEditorComponent implements OnInit {
     portNext: undefined,
     portOfCall: undefined,
     portPrevious: undefined,
-    timestampDefinition: undefined,
+    timestampDefinitionTO: undefined,
     transportCallID: "",
-    transportCallReference:""
+    transportCallReference:"",
+    carrierVoyageNumber:""
   };
 
 
@@ -136,7 +137,7 @@ export class TimestampEditorComponent implements OnInit {
     timestamp.publisher = this.globals.config.publisher;
     timestamp.publisherRole = null;
     timestamp.delayReasonCode = (this.delayCode ? this.delayCode.smdgCode : null);
-    timestamp.timestampDefinition = this.timestampSelected;
+    timestamp.timestampDefinitionTO = this.timestampSelected;
 
     timestamp.facilitySMDGCode = (this.terminalSelected?.facilitySMDGCode ? this.terminalSelected?.facilitySMDGCode : null);
 

--- a/src/app/view/timestamp-table/timestamp-table.component.html
+++ b/src/app/view/timestamp-table/timestamp-table.component.html
@@ -118,7 +118,7 @@
                 <div class="rowDetails">{{ (timestamp.vessel | vesselIdToVessel: vessels).serviceNameCode}}</div>
             </td>
             <td style="width: 7%" [ngClass]="'timestampContent'">
-                {{ timestamp.timestampDefinition?.timestampTypeName || 'UNKNOWN' }}
+                {{ timestamp.timestampDefinitionTO?.timestampTypeName || 'UNKNOWN' }}
             </td>
             <td pTooltip="UTC: {{(timestamp.logOfTimestamp | timestampToTimezone: timestamp.portOfCall)[1]}}"
                 style="width: 15%; opacity: 0.6;" [ngClass]="'timestampContent'">
@@ -182,17 +182,17 @@
                     </div>
 
                     <div class="timestampContent__buttons acceptBtn"
-                        *ngIf="timestamp.isLatestInCycle && isPrimary(timestamp) && timestamp.timestampDefinition?.acceptTimestampDefinition != null && !isOutGoing(timestamp)">
+                        *ngIf="timestamp.isLatestInCycle && isPrimary(timestamp) && timestamp.timestampDefinitionTO?.acceptTimestampDefinition != null && !isOutGoing(timestamp)">
                         <p-button icon="pi pi-check"
-                            pTooltip="{{ 'general.table.accept.tooltip' | translate }} {{timestamp.timestampDefinition?.acceptTimestampDefinitionEntity.timestampTypeName}}"
+                            pTooltip="{{ 'general.table.accept.tooltip' | translate }} {{timestamp.timestampDefinitionTO?.acceptTimestampDefinitionEntity.timestampTypeName}}"
                             tooltipPosition="left" tooltipStyleClass="ToolTipClass"
                             (click)="openAcceptDialog(timestamp)"></p-button>
                     </div>
 
                     <div class="timestampContent__buttons declineBtn"
-                        *ngIf="timestamp.isLatestInCycle && isPrimary(timestamp) && timestamp.timestampDefinition?.rejectTimestampDefinition != null && !isOutGoing(timestamp)">
+                        *ngIf="timestamp.isLatestInCycle && isPrimary(timestamp) && timestamp.timestampDefinitionTO?.rejectTimestampDefinition != null && !isOutGoing(timestamp)">
                         <p-button icon="pi pi-times"
-                            pTooltip="{{ 'general.table.decline.tooltip' | translate }}  {{timestamp.timestampDefinition?.rejectTimestampDefinitionEntity.timestampTypeName}}"
+                            pTooltip="{{ 'general.table.decline.tooltip' | translate }}  {{timestamp.timestampDefinitionTO?.rejectTimestampDefinitionEntity.timestampTypeName}}"
                             tooltipPosition="left" tooltipStyleClass="ToolTipClass"
                             (click)="openRejectDialog(timestamp)"></p-button>
                     </div>

--- a/src/app/view/timestamp-table/timestamp-table.component.ts
+++ b/src/app/view/timestamp-table/timestamp-table.component.ts
@@ -21,7 +21,7 @@ import { TimestampService } from "../../controller/services/jit/timestamps.servi
 import { Timestamp } from 'src/app/model/jit/timestamp';
 import { NegotiationCycle } from "../../model/portCall/negotiation-cycle";
 import { TimestampDefinitionService } from "../../controller/services/base/timestamp-definition.service";
-import { TimestampDefinition } from "../../model/jit/timestamp-definition";
+import { timestampDefinitionTO } from "../../model/jit/timestamp-definition";
 
 @Component({
   selector: 'app-timestamp-table',
@@ -47,7 +47,7 @@ export class TimestampTableComponent implements OnInit, OnChanges {
   negotiationCycles: SelectItem[] = [];
   portCallParts: SelectItem[] = [];
   selectedPortCallPart: string = null;
-  timestampDefinitionMap: Map<string, TimestampDefinition> = new Map<string, TimestampDefinition>();
+  timestampDefinitionMap: Map<string, timestampDefinitionTO> = new Map<string, timestampDefinitionTO>();
   selectedNegotiationCycle: NegotiationCycle = null;
 
   @Output('timeStampDeletedNotifier') timeStampDeletedNotifier: EventEmitter<Timestamp> = new EventEmitter<Timestamp>()
@@ -87,7 +87,7 @@ export class TimestampTableComponent implements OnInit, OnChanges {
   }
 
   public isPrimary(timestamp: Timestamp): boolean {
-    return this.globals.config.publisherRoles.includes(timestamp.timestampDefinition?.primaryReceiver);
+    return this.globals.config.publisherRoles.includes(timestamp.timestampDefinitionTO?.primaryReceiver);
   }
 
   filterTimestampsByPortOfCallPart() {
@@ -97,7 +97,7 @@ export class TimestampTableComponent implements OnInit, OnChanges {
 
   private populatePortCallParts() {
     this.selectedPortCallPart = null;
-    let uniqueParts = new Set(this.timestamps.map(timestamp => timestamp.timestampDefinition?.portCallPart).filter((value) => {
+    let uniqueParts = new Set(this.timestamps.map(timestamp => timestamp.timestampDefinitionTO?.portCallPart).filter((value) => {
       return value !== undefined;
     }));
 
@@ -160,7 +160,7 @@ export class TimestampTableComponent implements OnInit, OnChanges {
       //
       // If you are here because you want to double check the "secondary timestamp" flow, just remove
       // the relevant roles from "publisherRoles" from config.json. :)
-      (!timestamp.timestampDefinition || !publisherRoles.includes(timestamp.timestampDefinition.primaryReceiver));
+      (!timestamp.timestampDefinitionTO || !publisherRoles.includes(timestamp.timestampDefinitionTO.primaryReceiver));
   }
 
   showComment(timestamp: Timestamp) {
@@ -192,7 +192,7 @@ export class TimestampTableComponent implements OnInit, OnChanges {
 
   openAcceptDialog(timestamp: Timestamp) {
     let timestampShallowClone = Object.assign({}, timestamp);
-    timestampShallowClone.timestampDefinition = timestamp.timestampDefinition.acceptTimestampDefinitionEntity;
+    timestampShallowClone.timestampDefinitionTO = timestamp.timestampDefinitionTO.acceptTimestampDefinitionEntity;
     timestampShallowClone.logOfTimestamp = new Date();
     // Avoid cloning the remark and delayReasonCode from the original sender.  It would just be confusing to them
     // so see their own comment in a reply to them.
@@ -217,7 +217,7 @@ export class TimestampTableComponent implements OnInit, OnChanges {
   }
   openRejectDialog(timestamp: Timestamp) {
     let timestampShallowClone = Object.assign({}, timestamp);
-    timestampShallowClone.timestampDefinition = timestamp.timestampDefinition.rejectTimestampDefinitionEntity;
+    timestampShallowClone.timestampDefinitionTO = timestamp.timestampDefinitionTO.rejectTimestampDefinitionEntity;
     timestampShallowClone.logOfTimestamp = new Date();
     // Avoid cloning the remark and delayReasonCode from the original sender.  It would just be confusing to them
     // so see their own comment in a reply to them.

--- a/src/app/view/transport-call-creator/transport-call-creator.component.ts
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.ts
@@ -26,7 +26,7 @@ import {EventLocation} from "../../model/eventLocation";
 import {VesselPosition} from "../../model/vesselPosition";
 import { PortService } from 'src/app/controller/services/base/port.service';
 import { TerminalService } from 'src/app/controller/services/base/terminal.service';
-import {TimestampDefinition} from "../../model/jit/timestamp-definition";
+import {timestampDefinitionTO} from "../../model/jit/timestamp-definition";
 import {TimestampDefinitionService} from "../../controller/services/base/timestamp-definition.service";
 
 @Component({
@@ -48,8 +48,8 @@ export class TransportCallCreatorComponent implements OnInit {
   timestamp: Timestamp;
   eventTimestampDate: Date;
   eventTimestampTime: string;
-  timestampSelected: TimestampDefinition;
-  timestampDefinitions: TimestampDefinition[] = [];
+  timestampSelected: timestampDefinitionTO;
+  timestampDefinitions: timestampDefinitionTO[] = [];
   timestampTypes: SelectItem[] = [];
   delayCodeOptions: SelectItem[] = [];
   delayCodes: DelayCode[];
@@ -301,7 +301,8 @@ export class TransportCallCreatorComponent implements OnInit {
       vesselIMONumber: string;
       delayReasonCode: string;
       transportCallReference: string;
-      timestampDefinition: TimestampDefinition;
+      timestampDefinitionTO: timestampDefinitionTO;
+      carrierVoyageNumber: string;
     }
 
     if (this.shouldCreateTimestamp() && createTimestamp) {
@@ -348,7 +349,7 @@ export class TransportCallCreatorComponent implements OnInit {
       let time = this.transportCallFormGroup.controls.eventTimestampTime.value;
       this.timestamp.eventDateTime = this.dateToUTC.transform(date, time, this.portOfCall.timezone);
 
-      this.timestamp.timestampDefinition = this.timestampSelected;
+      this.timestamp.timestampDefinitionTO = this.timestampSelected;
 
       this.creationProgress = true;
       this.timestampMappingService.addPortCallTimestamp(this.timestamp).subscribe(() => {


### PR DESCRIPTION
- rename timestampDefinition to timestampDefinitionTO on TimestampInfo
- check for null in extractVesselAttributes
- include timestampDefinitionsMap in mapping service to add acceptTimestampDefinitionEntity & rejectTimestampDefinitionEntity to timestampInfo
- Comment is added to ticket raised in [DDT-575](https://dcsa.atlassian.net/browse/DDT-575) 