### PR TITLE
Improve User Experience

### DIFF
--- a/src/app/model/jit/config.ts
+++ b/src/app/model/jit/config.ts
@@ -3,7 +3,6 @@ import { IdentifyingCode } from "../portCall/identifyingCode";
 import { Publisher } from "../publisher";
 
 export interface Config {
-  enableJIT11Timestamps: Boolean;
   company: string;
   publisherRoles: PublisherRole[];
   publisher: Publisher;

--- a/src/app/model/jit/timestamp-definition.ts
+++ b/src/app/model/jit/timestamp-definition.ts
@@ -1,5 +1,4 @@
 import { OperationsEventTypeCode } from '../enums/operationsEventTypeCode';
-import { PublisherRole } from '../enums/publisherRole';
 import { EventClassifierCode } from "./event-classifier-code";
 import { PortCallPhaseTypeCode } from "../enums/portCallPhaseTypeCode";
 import { PortCallServiceTypeCode } from "../enums/portCallServiceTypeCode";
@@ -31,17 +30,5 @@ export interface TimestampDefinitionTO {
   eventLocationRequirement: EventLocationRequirement;
   negotiationCycle: NegotiationCycle;
   implicitVariantOf: string;
-
-  /**
-* @deprecated
-
-detected through publisherPattern field & then set by mapping
-*/
-  publisherRole: PublisherRole;
-  /**
-* @deprecated
-detected through publisherPattern field & then set by mapping
-*/
-  primaryReceiver: PublisherRole;
 
 }

--- a/src/app/model/jit/timestamp-definition.ts
+++ b/src/app/model/jit/timestamp-definition.ts
@@ -30,6 +30,7 @@ export interface TimestampDefinitionTO {
   rejectTimestampDefinitionEntity?: TimestampDefinitionTO;
   eventLocationRequirement: EventLocationRequirement;
   negotiationCycle: NegotiationCycle;
+  implicitVariantOf: string;
 
   /**
 * @deprecated

--- a/src/app/model/portCall/negotiation-cycle.ts
+++ b/src/app/model/portCall/negotiation-cycle.ts
@@ -1,4 +1,5 @@
 export interface NegotiationCycle {
   cycleName: string; // E.g., "Arrival at Berth" or "Start Cargo OPS"
   cycleKey: string; // E.g.,  "TA-Berth" or "TS-Cargo OPS"
+  displayOrder: bigint; // Number to order them after how "important" the cycle is.
 }

--- a/src/app/view/port-of-call/port-of-call.component.html
+++ b/src/app/view/port-of-call/port-of-call.component.html
@@ -6,6 +6,7 @@
         (onChange)="selectPortOfCall()"
         [(ngModel)]="portOfCall"
         [filter]="true"
+        [showClear]=true
         [options]="portOptions"
         filterBy="label,value.UNLocationCode">
         <ng-template let-port pTemplate="item">

--- a/src/app/view/timestamp-editor/timestamp-editor.component.html
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.html
@@ -57,6 +57,7 @@
       <label for="negotiationCycle">{{ 'general.table.header.negotiationCycle.label' | translate }}: </label>
       <p-dropdown id="negotiationCycle" styleClass="dropdown" formControlName="negotiationCycle"
                   [options]="negotiationCycles"
+                  [showClear]=true
                   [filter]=true filterBy="label" appendTo="body"
                   (onChange)="onSelectedNegotiationCycle($event)">
 
@@ -132,8 +133,13 @@
   <!-- Delay Code dropdown -->
   <div class="md:col-6">
     <label for="delayCode">{{"general.delaycode.label" | translate}}</label>
-    <p-dropdown appendTo="body" id="delayCode" [options]="delayCodeOptions" formControlName="delayCode" [filter]="true"
-      filterBy="label,value.name" [group]="false">
+    <p-dropdown appendTo="body" id="delayCode"
+                [options]="delayCodeOptions"
+                formControlName="delayCode"
+                [filter]="true"
+                [showClear]=true
+                filterBy="label,value.name"
+                [group]="false">
       <ng-template let-delayCode pTemplate="selectedItem">
         <div *ngIf="delayCode.value" class="delayCodeSelectedWrapper">
           <div class="delayCodeSelected__smdgCode">{{delayCode.value.smdgCode}}</div>

--- a/src/app/view/timestamp-editor/timestamp-editor.component.ts
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.ts
@@ -306,6 +306,10 @@ export class TimestampEditorComponent implements OnInit {
     this.timestampTypes = [];
     this.timestampTypes.push({ label: this.translate.instant('general.timestamp.select'), value: null });
     for (let timestampDef of this.timestampDefinitions) {
+      if (timestampDef.implicitVariantOf) {
+        // Ignore the implicit versions that have an explicit version.
+        continue;
+      }
       if (this.selectedNegotiationCycle && timestampDef.negotiationCycle.cycleKey != this.selectedNegotiationCycle.cycleKey) {
         continue;
       }

--- a/src/app/view/timestamp-editor/timestamp-editor.component.ts
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.ts
@@ -316,9 +316,6 @@ export class TimestampEditorComponent implements OnInit {
       if (!timestampDef.publisherPattern.some(pr => this.globals.config.publisherRoles.includes(pr.publisherRole))) {
         continue;
       }
-      if (!this.globals.config.enableJIT11Timestamps && timestampDef.providedInStandard == 'jit1_1') {
-        continue
-      }
       this.timestampTypes.push({ label: timestampDef.timestampTypeName, value: timestampDef })
     }
   }

--- a/src/app/view/timestamp-table/timestamp-table.component.html
+++ b/src/app/view/timestamp-table/timestamp-table.component.html
@@ -34,10 +34,12 @@
             <div class="col">
                 <p-dropdown id="negotiationCycle" styleClass="dropdown" [(ngModel)]="filterNegotiationCycle"
                     [options]="filterNegotiationCycles" [filter]=true filterBy="label" appendTo="body"
+                    [showClear]=true
                     (onChange)="filterSelected()">
                 </p-dropdown>
                 <p-dropdown id="portCallPart" styleClass="dropdown" [(ngModel)]="selectedPortCallPart"
                     [options]="portCallParts" [filter]=true filterBy="label" appendTo="body"
+                    [showClear]=true
                     (onChange)="filterTimestampsByPortOfCallPart()">
                 </p-dropdown>
             </div>

--- a/src/app/view/transport-call-creator/transport-call-creator.component.html
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.html
@@ -79,6 +79,7 @@
       <label for="negotiationCycle">{{ 'general.table.header.negotiationCycle.label' | translate }}: </label>
       <p-dropdown id="negotiationCycle" styleClass="dropdown" formControlName="negotiationCycle"
                   [options]="negotiationCycles"
+                  [showClear]=true
                   [filter]=true filterBy="label" appendTo="body"
                   (onChange)="onSelectedNegotiationCycle($event)">
 
@@ -170,8 +171,14 @@
     <!-- Delay Code -->
     <div class="md:col-6" [hidden]="!shouldCreateTimestamp()">
       <label for="delayCode">{{"general.delaycode.label" | translate}}</label>
-      <p-dropdown id="delayCode" [options]="delayCodeOptions" formControlName="delayCode" [filter]="true"
-        filterBy="label,value.name" [group]="false">
+      <p-dropdown id="delayCode"
+                  [options]="delayCodeOptions"
+                  formControlName="delayCode"
+                  [filter]="true"
+                  [showClear]=true
+                  filterBy="label,value.name"
+                  appendTo="body"
+                  [group]="false">
         <ng-template let-delayCode pTemplate="selectedItem">
           <div *ngIf="delayCode.value" class="delayCodeSelectedWrapper">
             <div class="delayCodeSelected__smdgCode">{{delayCode.value.smdgCode}}</div>

--- a/src/app/view/transport-call-creator/transport-call-creator.component.ts
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.ts
@@ -211,9 +211,6 @@ export class TransportCallCreatorComponent implements OnInit {
       if (!timestampDef.publisherPattern.some(pr => this.globals.config.publisherRoles.includes(pr.publisherRole))) {
         continue;
       }
-      if (!this.globals.config.enableJIT11Timestamps && timestampDef.providedInStandard == 'jit1_1') {
-        continue
-      }
       this.timestampTypes.push({ label: timestampDef.timestampTypeName, value: timestampDef })
     }
   }

--- a/src/app/view/transport-call-creator/transport-call-creator.component.ts
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.ts
@@ -201,6 +201,10 @@ export class TransportCallCreatorComponent implements OnInit {
     this.timestampTypes = [];
     this.timestampTypes.push({ label: this.translate.instant('general.timestamp.select'), value: null });
     for (let timestampDef of this.timestampDefinitions) {
+      if (timestampDef.implicitVariantOf) {
+        // Ignore the implicit versions that have an explicit version.
+        continue;
+      }
       if (this.selectedNegotiationCycle && timestampDef.negotiationCycle.cycleKey != this.selectedNegotiationCycle.cycleKey) {
         continue;
       }

--- a/src/app/view/vessel/vessel.component.html
+++ b/src/app/view/vessel/vessel.component.html
@@ -6,7 +6,11 @@
       <div class="vessel__content__first">
         <div class="vessel__select_modify">
           <div class="dropDownDiv">
-            <p-dropdown (onChange)="selectVessel()" [(ngModel)]="selectedVessel" [filter]="true" [options]="vessels"></p-dropdown>
+            <p-dropdown (onChange)="selectVessel()"
+                        [(ngModel)]="selectedVessel"
+                        [filter]="true"
+                        [showClear]=true
+                        [options]="vessels"></p-dropdown>
           </div>
 
           <div class="vessel__select_modify__buttons">

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -18,7 +18,6 @@
   "uiSupportBackendURL": "http://localhost:9091/v1",
   "jitBackendURL": "http://localhost:9090/v1",
   "dateTimeFormat": "dd MMM yyyy HH:mm",
-  "enableJIT11Timestamps": true,
   "enableVesselPositions": true,
   "authRegion":"eu-west-1",
   "authUserPoolId": "eu-west-1_khrRmnDXz",

--- a/src/assets/devconfig.json
+++ b/src/assets/devconfig.json
@@ -18,7 +18,6 @@
     "uiSupportBackendURL": "/uisupport",
     "jitBackendURL": "/jit",
     "dateTimeFormat": "dd MMM yyyy HH:mm",
-    "enableJIT11Timestamps": true,
     "enableVesselPositions": true,
     "authRegion":"eu-west-1",
     "authUserPoolId": "eu-west-1_khrRmnDXz",


### PR DESCRIPTION
- Hide implicit timestamps that have a non-implicit variant in the select timestamps (which is all of them and therefore, the user does not need to know the difference between implicit
 and explicit when selecting timestamps)
- Add an easy way to clear a number of filters and optional fields.
- Order negotiation cycles by their "importance" (displayOrder) so that the most common ones are in top.


Additionally, there are some minor code simplifications.