### PR TITLE
DDT-1242: Show full name of publisher roles when users can select them

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -70,6 +70,13 @@
                   "maximumError": "512kb"
                 }
               ]
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true
             }
           }
         },
@@ -82,8 +89,12 @@
           "configurations": {
             "production": {
               "browserTarget": "ui:build:production"
+            },
+            "development": {
+              "browserTarget": "ui:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -55,6 +55,7 @@ import { AmplifyUIAngularModule } from '@aws-amplify/ui-angular';
 import { DebounceClickDirective } from "./controller/services/util/debounce-click.directive";
 import {ShowTimestampAsJsonDialogComponent} from "./view/show-json-dialog/show-timestamp-as-json-dialog.component";
 import {MatTabsModule} from "@angular/material/tabs";
+import {RippleModule} from 'primeng/ripple';
 
 export function HttpLoaderFactory(http: HttpClient) {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -123,6 +124,7 @@ export function ConfigLoader(configService: ConfigService) {
     }),
     MenuModule,
     MatTabsModule,
+    RippleModule,
   ],
   providers: [
     ConfigService,

--- a/src/app/controller/services/base/port.service.ts
+++ b/src/app/controller/services/base/port.service.ts
@@ -56,7 +56,10 @@ export class PortService {
             cachePort(this.unlocode2PortCache, port);
           }
         }),
-        shareReplay(1)
+        shareReplay({
+          bufferSize: 1,
+          refCount: true,
+        })
       ) as Observable<Port[]>;
     }
     return this.ports$;

--- a/src/app/controller/services/base/publisher-role.service.ts
+++ b/src/app/controller/services/base/publisher-role.service.ts
@@ -1,0 +1,27 @@
+import {Observable} from 'rxjs';
+import {PublisherRoleDetail} from '../../../model/enums/publisherRole';
+import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {Globals} from '../../../model/portCall/globals';
+import {shareReplay} from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PublisherRoleService {
+  private readonly PUBLISHER_ROLE_DETAILS_ENDPOINT: string;
+
+  constructor(private httpClient: HttpClient,
+              private globals: Globals) {
+    this.PUBLISHER_ROLE_DETAILS_ENDPOINT = globals.config.uiSupportBackendURL + '/unofficial/publisher-roles';
+  }
+
+  getPublisherRoleDetails = (): Observable<PublisherRoleDetail[]> =>
+    this.httpClient.get<PublisherRoleDetail[]>(this.PUBLISHER_ROLE_DETAILS_ENDPOINT).pipe(
+      shareReplay({
+        bufferSize: 1,
+        refCount: true,
+      })
+    )
+
+}

--- a/src/app/controller/services/base/timestamp-definition.service.ts
+++ b/src/app/controller/services/base/timestamp-definition.service.ts
@@ -60,7 +60,10 @@ export class TimestampDefinitionService {
             }
             return definitions;
           }),
-          shareReplay(1)
+          shareReplay({
+            bufferSize: 1,
+            refCount: true,
+          })
         ) as Observable<TimestampDefinitionTO[]>;
     }
     return this.definitionCache$;
@@ -81,7 +84,10 @@ export class TimestampDefinitionService {
           uniqueNegotiationCycles.sort(negotiationCycleComparator)
           return uniqueNegotiationCycles
         }),
-        shareReplay(1)
+        shareReplay({
+          bufferSize: 1,
+          refCount: true,
+        })
       ) as Observable<NegotiationCycle[]>
     }
     return this.negotiationCyclesCache$;
@@ -103,7 +109,10 @@ export class TimestampDefinitionService {
             };
           });
         }),
-        shareReplay(1)
+        shareReplay({
+          bufferSize: 1,
+          refCount: true,
+        })
       );
     }
     return this.portCallPartCache$;
@@ -115,7 +124,10 @@ export class TimestampDefinitionService {
         map(timestampDefinitions => {
           return asMap(timestampDefinitions);
         }),
-        shareReplay(1)
+        shareReplay({
+          bufferSize: 1,
+          refCount: true,
+        })
       ) as Observable<Map<string, TimestampDefinitionTO>>;
     }
     return this.definitionMapCache$;

--- a/src/app/model/enums/publisherRole.ts
+++ b/src/app/model/enums/publisherRole.ts
@@ -12,5 +12,10 @@ export enum PublisherRole {
 
   SLU = 'SLU', // Sludge service provider
   SVP = 'SVP', // Other service provider
-  MOR = 'MOR', // Moording service provider
+  MOR = 'MOR', // Mooring service provider
+}
+
+export interface PublisherRoleDetail {
+  publisherRole: PublisherRole;
+  publisherRoleName: string;
 }

--- a/src/app/model/jit/timestamp.ts
+++ b/src/app/model/jit/timestamp.ts
@@ -6,7 +6,6 @@ import { EventLocation } from "../eventLocation";
 import { VesselPosition } from "../vesselPosition";
 import { ModeOfTransport } from "../enums/modeOfTransport";
 import { PortCallServiceTypeCode } from "../enums/portCallServiceTypeCode";
-import { Port } from "../../model/portCall/port";
 import { EventClassifierCode } from "./event-classifier-code";
 import { NegotiationCycle } from "../portCall/negotiation-cycle";
 import { TimestampDefinitionTO } from "./timestamp-definition";

--- a/src/app/view/timestamp-editor/timestamp-editor.component.html
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.html
@@ -82,8 +82,14 @@
                   styleClass="dropdown"
                   formControlName="publisherRole"
                   [options]="publisherRoles"
+                  [filter]="true"
+                  filterBy="publisherRoleName,publisherRole"
+                  optionLabel="publisherRoleName"
                   placeholder="{{ 'general.publisherRole.select' | translate }}"
                   appendTo="body">
+        <ng-template let-publisherRoleDetail pTemplate="item">
+          <div>{{publisherRoleDetail.publisherRoleName}} ({{publisherRoleDetail.publisherRole}})</div>
+        </ng-template>
       </p-dropdown>
     </div>
   </ng-container>

--- a/src/app/view/timestamp-editor/timestamp-editor.component.html
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.html
@@ -74,8 +74,14 @@
 
   <div class="md:col-6" [hidden]="!showPublisherRoleOption()">
     <label for="timestampType">{{ 'general.publisherRole.label' | translate }}: </label>
-    <p-dropdown id="publisherRole" styleClass="dropdown" formControlName="publisherRole"
-      [options]="publisherRoleOptions" appendTo="body"></p-dropdown>
+    <p-dropdown id="publisherRole"
+                styleClass="dropdown"
+                formControlName="publisherRole"
+                [options]="publisherRoleOptions"
+                placeholder="{{ 'general.publisherRole.select' | translate }}"
+                appendTo="body">
+
+    </p-dropdown>
   </div>
 
   <div class="md:col-6" *ngIf="timestampResponseStatus !== TimestampResponseStatus.ACCEPT">

--- a/src/app/view/timestamp-editor/timestamp-editor.component.html
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.html
@@ -55,11 +55,14 @@
   <div class="md:col-6" *ngIf="timestampResponseStatus === TimestampResponseStatus.CREATE">
     <div>
       <label for="negotiationCycle">{{ 'general.table.header.negotiationCycle.label' | translate }}: </label>
-      <p-dropdown id="negotiationCycle" styleClass="dropdown" formControlName="negotiationCycle"
+      <p-dropdown id="negotiationCycle"
+                  styleClass="dropdown"
                   [options]="negotiationCycles$ | async"
                   [showClear]=true
                   optionLabel="cycleName"
-                  [filter]=true filterBy="cycleName" appendTo="body"
+                  [filter]=true
+                  filterBy="cycleName"
+                  appendTo="body"
                   (onChange)="onSelectedNegotiationCycle($event)"
                   placeholder="{{ 'general.negotiationCycle.select' | translate }}">
 

--- a/src/app/view/timestamp-editor/timestamp-editor.component.html
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.html
@@ -71,21 +71,22 @@
     <div>
       <label for="timestampType">{{ 'general.table.header.timestamp.label' | translate }}: </label>
       <p-dropdown id="timestampType" styleClass="dropdown" formControlName="timestampType" [options]="timestampTypes"
-        [filter]=true filterBy="label" appendTo="body" (onChange)="updatePublisherRoleOptions(); updateVesselPositionRequirement()"></p-dropdown>
+        [filter]=true filterBy="label" appendTo="body" (onChange)="updateTimestampDefinition();"></p-dropdown>
     </div>
   </div>
 
-  <div class="md:col-6" [hidden]="!showPublisherRoleOption()">
-    <label for="timestampType">{{ 'general.publisherRole.label' | translate }}: </label>
-    <p-dropdown id="publisherRole"
-                styleClass="dropdown"
-                formControlName="publisherRole"
-                [options]="publisherRoleOptions"
-                placeholder="{{ 'general.publisherRole.select' | translate }}"
-                appendTo="body">
-
-    </p-dropdown>
-  </div>
+  <ng-container *ngIf="selectablePublisherRoles$ | async as publisherRoles">
+    <div class="md:col-6" [hidden]="publisherRoles.length < 2">
+      <label for="publisherRole">{{ 'general.publisherRole.label' | translate }}: </label>
+      <p-dropdown id="publisherRole"
+                  styleClass="dropdown"
+                  formControlName="publisherRole"
+                  [options]="publisherRoles"
+                  placeholder="{{ 'general.publisherRole.select' | translate }}"
+                  appendTo="body">
+      </p-dropdown>
+    </div>
+  </ng-container>
 
   <div class="md:col-6" *ngIf="timestampResponseStatus !== TimestampResponseStatus.ACCEPT">
     <label for="eventtimestamp">{{ 'general.table.header.eventTimestamp.label' | translate }}: </label>
@@ -126,7 +127,6 @@
       {{ 'general.transportCall.validation.terminal.empty' | translate }}
     </span>
   </div>
-
   <!-- location name -->
   <div class="md:col-6" [hidden]="!showLocationNameOption()">
     <div class="p-field berth-location-field">
@@ -171,39 +171,7 @@
     </p-dropdown>
   </div>
 
-  <!-- Remarks box -->
-  <div class="md:col-6">
-    <span class="p-float-label">
-      <textarea id="commentbox" pInputTextarea formControlName="remark"></textarea>
-      <label for="commentbox">{{ 'general.comment.tooltip' | translate }}</label>
-    </span>
-  </div>
-
-  <!-- Vessel Position -->
-  <div class="md:col-6" [hidden]="!showVesselPosition()">
-    <label for="vesselPositionLatitude">{{ "general.timestamp.vesselPosition.latitude.label" | translate }}:</label>
-    <input id="vesselPositionLatitude" formControlName="vesselPositionLatitude" pInputText style="width: 100%"
-      type="text" />
-    <span *ngIf="timestampFormGroup.get('vesselPositionLatitude').hasError('maxlength')" class="p-invalid">
-      {{ 'general.timestamp.vesselPosition.latitude.maxLength' | translate }}
-    </span>
-    <span *ngIf="timestampFormGroup.get('vesselPositionLatitude').hasError('pattern')" class="p-invalid">
-      {{ 'general.timestamp.vesselPosition.latitude.pattern' | translate }}
-    </span>
-  </div>
-  <div class="md:col-6" [hidden]="!showVesselPosition()">
-    <label for="vesselPositionLongitude">{{ "general.timestamp.vesselPosition.longitude.label" | translate }}:</label>
-    <input id="vesselPositionLongitude" formControlName="vesselPositionLongitude" pInputText style="width: 100%"
-      type="text" />
-    <span *ngIf="timestampFormGroup.get('vesselPositionLongitude').hasError('maxlength')" class="p-invalid">
-      {{ 'general.timestamp.vesselPosition.longitude.maxLength' | translate }}
-    </span>
-    <span *ngIf="timestampFormGroup.get('vesselPositionLongitude').hasError('pattern')" class="p-invalid">
-      {{ 'general.timestamp.vesselPosition.longitude.pattern' | translate }}
-    </span>
-  </div>
-
-  <!-- Miles remaning -->
+  <!-- Miles remaining -->
   <div class="md:col-6" [hidden]="!showMilesToDestinationPortOption()">
     <label for="milesToDestinationPort">{{ "general.timestamp.milesToDestinationPort.label" | translate }}:</label>
     <input id="milesToDestinationPort" formControlName="milesToDestinationPort" pInputText style="width: 100%"
@@ -217,7 +185,7 @@
   <div class="md:col-6">
     <label for="vesselDraft">{{ "general.timestamp.vesselDraft.label" | translate }}:</label>
     <input id="vesselDraft" formControlName="vesselDraft" pInputText style="width: 100%"
-      type="text" />
+           type="text" />
     <span *ngIf="timestampFormGroup.get('vesselDraft').hasError('pattern')" class="p-invalid">
       {{ 'general.timestamp.vesselDraft.pattern' | translate }}
     </span>
@@ -225,6 +193,41 @@
       {{ 'general.timestamp.vesselDraft.missingUnit' | translate }}
     </span>
   </div>
+
+  <!-- Vessel Position -->
+  <ng-container *ngIf="showVesselPosition$ | async as showVesselPosition">
+    <div class="md:col-6" [hidden]="!showVesselPosition">
+      <label for="vesselPositionLatitude">{{ "general.timestamp.vesselPosition.latitude.label" | translate }}:</label>
+      <input id="vesselPositionLatitude" formControlName="vesselPositionLatitude" pInputText style="width: 100%"
+             type="text" />
+      <span *ngIf="timestampFormGroup.get('vesselPositionLatitude').hasError('maxlength')" class="p-invalid">
+        {{ 'general.timestamp.vesselPosition.latitude.maxLength' | translate }}
+      </span>
+      <span *ngIf="timestampFormGroup.get('vesselPositionLatitude').hasError('pattern')" class="p-invalid">
+        {{ 'general.timestamp.vesselPosition.latitude.pattern' | translate }}
+      </span>
+    </div>
+    <div class="md:col-6" [hidden]="!showVesselPosition">
+      <label for="vesselPositionLongitude">{{ "general.timestamp.vesselPosition.longitude.label" | translate }}:</label>
+      <input id="vesselPositionLongitude" formControlName="vesselPositionLongitude" pInputText style="width: 100%"
+             type="text" />
+      <span *ngIf="timestampFormGroup.get('vesselPositionLongitude').hasError('maxlength')" class="p-invalid">
+        {{ 'general.timestamp.vesselPosition.longitude.maxLength' | translate }}
+      </span>
+      <span *ngIf="timestampFormGroup.get('vesselPositionLongitude').hasError('pattern')" class="p-invalid">
+        {{ 'general.timestamp.vesselPosition.longitude.pattern' | translate }}
+      </span>
+    </div>
+  </ng-container>
+
+  <!-- Remarks box -->
+  <div class="md:col-6">
+    <span class="p-float-label">
+      <textarea id="commentbox" pInputTextarea formControlName="remark"></textarea>
+      <label for="commentbox">{{ 'general.comment.tooltip' | translate }}</label>
+    </span>
+  </div>
+
 </div>
 
 <div class="grid">

--- a/src/app/view/timestamp-editor/timestamp-editor.component.ts
+++ b/src/app/view/timestamp-editor/timestamp-editor.component.ts
@@ -117,7 +117,7 @@ export class TimestampEditorComponent implements OnInit {
 
   determineTimestampResponseStatus() {
     if (this.timestampResponseStatus === TimestampResponseStatus.CREATE) {
-      this.negotiationCycles$ = this.timestampDefinitionService.getNegotiationCycles(); 
+      this.negotiationCycles$ = this.timestampDefinitionService.getNegotiationCycles();
       this.timestampDefinitionService.getTimestampDefinitions().pipe(take(1)).subscribe(timestampDefinitions => {
         this.timestampDefinitions = timestampDefinitions;
         this.updateTimestampTypeOptions();
@@ -335,11 +335,9 @@ export class TimestampEditorComponent implements OnInit {
 
   updatePublisherRoleOptions() {
     this.publisherRoles = this.timestampMappingService.overlappingPublisherRoles(this?.timestampTypeSelected?.value);
-    this.publisherRoleOptions = [];
-    this.publisherRoleOptions.push({ label: this.translate.instant('general.publisherRole.select'), value: null });
-    this.publisherRoles.forEach(pr => {
-      this.publisherRoleOptions.push({ label: pr, value: pr })
-    })
+    this.publisherRoleOptions = this.publisherRoles.map(pr => {
+      return { label: pr, value: pr };
+    });
   }
 
   defaultTerminalValue() {

--- a/src/app/view/timestamp-table/timestamp-table.component.ts
+++ b/src/app/view/timestamp-table/timestamp-table.component.ts
@@ -111,7 +111,10 @@ export class TimestampTableComponent implements OnInit, OnChanges {
           });
         }),
         tap(timestampInfos => this.colorizetimestampByLocation(timestampInfos)),
-        shareReplay(1),
+        shareReplay({
+          bufferSize: 1,
+          refCount: true,
+        })
       );
     }
   }

--- a/src/app/view/transport-call-creator/transport-call-creator.component.html
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.html
@@ -102,7 +102,7 @@
 
       <label for="timestampType">{{ 'general.table.header.timestamp.label' | translate }}: </label>
       <p-dropdown id="timestampType" formControlName="timestampType" styleClass="dropdown" [options]="timestampTypes"
-        [filter]=true filterBy="label" appendTo="body" (onChange)="updatePublisherRoleOptions(); updateVesselPositionRequirement()">
+        [filter]=true filterBy="label" appendTo="body" (onChange)="updateTimestampDefinition();">
       </p-dropdown>
       <span
         *ngIf="transportCallFormGroup.get('timestampType').hasError('required') && transportCallFormGroup.get('timestampType').touched "
@@ -112,17 +112,18 @@
     </div>
 
     <!-- publisherRole dropdown-->
-    <div class="md:col-6" [hidden]="!showPublisherRoleOption() || !shouldCreateTimestamp()">
-      <label for="timestampType">{{ 'general.publisherRole.label' | translate }}: </label>
-      <p-dropdown id="publisherRole"
-                  styleClass="dropdown"
-                  formControlName="publisherRole"
-                  [options]="publisherRoleOptions"
-                  placeholder="{{ 'general.publisherRole.select' | translate }}"
-                  appendTo="body">
-
-      </p-dropdown>
-    </div>
+    <ng-container *ngIf="selectablePublisherRoles$ | async as publisherRoles">
+      <div class="md:col-6" [hidden]="publisherRoles.length < 2 || !shouldCreateTimestamp()">
+        <label for="publisherRole">{{ 'general.publisherRole.label' | translate }}: </label>
+        <p-dropdown id="publisherRole"
+                    styleClass="dropdown"
+                    formControlName="publisherRole"
+                    [options]="publisherRoles"
+                    placeholder="{{ 'general.publisherRole.select' | translate }}"
+                    appendTo="body">
+        </p-dropdown>
+      </div>
+    </ng-container>
 
     <!-- create event timestamp calender-->
     <div class="md:col-6" [hidden]="!shouldCreateTimestamp()">
@@ -156,7 +157,7 @@
       <label for="terminal">{{ 'general.terminal.label' | translate }}:</label>
 
 
-      <p-dropdown appendTo="body" formControlName="terminal" id="terminal" [options]="terminals$ | async" appendTo="body"
+      <p-dropdown appendTo="body" formControlName="terminal" id="terminal" [options]="terminals$ | async"
         optionLabel="facilitySMDGCode"
         [showClear]=true
         [filter]="true"
@@ -225,52 +226,34 @@
       </p-dropdown>
     </div>
 
-
-    <!-- Delay Remark -->
-    <div class="md:col-6" [hidden]="!shouldCreateTimestamp()">
-      <span class="p-float-label">
-        <textarea pInputTextarea id="commentbox" formControlName="defaultTimestampRemark"
-          [readOnly]="!shouldCreateTimestamp()"></textarea>
-        <label for="commentbox">{{ 'general.comment.tooltip' | translate }}</label>
-      </span>
-    </div>
-
     <!-- Vessel latitude -->
-    <div class="md:col-6" [hidden]="!showVesselPosition() || !shouldCreateTimestamp() ">
-      <label for="vesselPositionLatitude">{{ "general.timestamp.vesselPosition.latitude.label" | translate
-        }}:</label>
-      <input id="vesselPositionLatitude" formControlName="vesselPositionLatitude" pInputText style="width: 100%"
-        type="text" />
-      <span *ngIf="transportCallFormGroup.get('vesselPositionLatitude').hasError('maxlength')" class="p-invalid">
-        {{ 'general.timestamp.vesselPosition.latitude.maxLength' | translate }}
-      </span>
-      <span *ngIf="transportCallFormGroup.get('vesselPositionLatitude').hasError('pattern')" class="p-invalid">
-        {{ 'general.timestamp.vesselPosition.latitude.pattern' | translate }}
-      </span>
-    </div>
+    <ng-container *ngIf="showVesselPosition$ | async as showVesselPosition">
+      <div class="md:col-6" [hidden]="!showVesselPosition || !shouldCreateTimestamp() ">
+        <label for="vesselPositionLatitude">{{ "general.timestamp.vesselPosition.latitude.label" | translate
+          }}:</label>
+        <input id="vesselPositionLatitude" formControlName="vesselPositionLatitude" pInputText style="width: 100%"
+          type="text" />
+        <span *ngIf="transportCallFormGroup.get('vesselPositionLatitude').hasError('maxlength')" class="p-invalid">
+          {{ 'general.timestamp.vesselPosition.latitude.maxLength' | translate }}
+        </span>
+        <span *ngIf="transportCallFormGroup.get('vesselPositionLatitude').hasError('pattern')" class="p-invalid">
+          {{ 'general.timestamp.vesselPosition.latitude.pattern' | translate }}
+        </span>
+      </div>
 
-    <!--vessel longitude-->
-    <div class="md:col-6" [hidden]="!showVesselPosition() || !shouldCreateTimestamp()">
-      <label for="vesselPositionLongitude">{{ "general.timestamp.vesselPosition.longitude.label" | translate }}:</label>
-      <input id="vesselPositionLongitude" formControlName="vesselPositionLongitude" pInputText style="width: 100%"
-        type="text" />
-      <span *ngIf="transportCallFormGroup.get('vesselPositionLongitude').hasError('maxlength')" class="p-invalid">
-        {{ 'general.timestamp.vesselPosition.longitude.maxLength' | translate }}
-      </span>
-      <span *ngIf="transportCallFormGroup.get('vesselPositionLongitude').hasError('pattern')" class="p-invalid">
-        {{ 'general.timestamp.vesselPosition.longitude.pattern' | translate }}
-      </span>
-    </div>
-
-    <!-- Miles remaning -->
-    <div class="md:col-6" [hidden]="!showMilesToDestinationPortOption() || !shouldCreateTimestamp()">
-      <label for="milesToDestinationPort">{{ "general.timestamp.milesToDestinationPort.label" | translate }}:</label>
-      <input id="milesToDestinationPort" formControlName="milesToDestinationPort" pInputText style="width: 100%"
-        type="text" />
-      <span *ngIf="transportCallFormGroup.get('milesToDestinationPort').hasError('pattern')" class="p-invalid">
-        {{ 'general.timestamp.milesToDestinationPort.pattern' | translate }}
-      </span>
-    </div>
+      <!-- Vessel longitude -->
+      <div class="md:col-6" [hidden]="!showVesselPosition || !shouldCreateTimestamp()">
+        <label for="vesselPositionLongitude">{{ "general.timestamp.vesselPosition.longitude.label" | translate }}:</label>
+        <input id="vesselPositionLongitude" formControlName="vesselPositionLongitude" pInputText style="width: 100%"
+          type="text" />
+        <span *ngIf="transportCallFormGroup.get('vesselPositionLongitude').hasError('maxlength')" class="p-invalid">
+          {{ 'general.timestamp.vesselPosition.longitude.maxLength' | translate }}
+        </span>
+        <span *ngIf="transportCallFormGroup.get('vesselPositionLongitude').hasError('pattern')" class="p-invalid">
+          {{ 'general.timestamp.vesselPosition.longitude.pattern' | translate }}
+        </span>
+      </div>
+    </ng-container>
 
       <!-- Vessel draft -->
   <div class="md:col-6" [hidden]="!shouldCreateTimestamp()">
@@ -284,6 +267,25 @@
       {{ 'general.timestamp.vesselDraft.missingUnit' | translate }}
     </span>
   </div>
+
+    <!-- Miles remaining -->
+    <div class="md:col-6" [hidden]="!showMilesToDestinationPortOption() || !shouldCreateTimestamp()">
+      <label for="milesToDestinationPort">{{ "general.timestamp.milesToDestinationPort.label" | translate }}:</label>
+      <input id="milesToDestinationPort" formControlName="milesToDestinationPort" pInputText style="width: 100%"
+             type="text" />
+      <span *ngIf="transportCallFormGroup.get('milesToDestinationPort').hasError('pattern')" class="p-invalid">
+        {{ 'general.timestamp.milesToDestinationPort.pattern' | translate }}
+      </span>
+    </div>
+
+    <!-- Delay Remark -->
+    <div class="md:col-6" [hidden]="!shouldCreateTimestamp()">
+      <span class="p-float-label">
+        <textarea pInputTextarea id="commentbox" formControlName="defaultTimestampRemark"
+                  [readOnly]="!shouldCreateTimestamp()"></textarea>
+        <label for="commentbox">{{ 'general.comment.tooltip' | translate }}</label>
+      </span>
+    </div>
 
   </div>
 

--- a/src/app/view/transport-call-creator/transport-call-creator.component.html
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.html
@@ -91,7 +91,7 @@
   <div class="p-fluid p-formgrid grid" [hidden]="!shouldCreateTimestamp()">
     <div class="md:col-6" [hidden]="!shouldCreateTimestamp()">
       <label for="negotiationCycle">{{ 'general.table.header.negotiationCycle.label' | translate }}: </label>
-      <p-dropdown id="negotiationCycle" styleClass="dropdown" formControlName="negotiationCycle"
+      <p-dropdown id="negotiationCycle" styleClass="dropdown"
       [options]="negotiationCycles$ | async"
       [showClear]=true
       optionLabel="cycleName"

--- a/src/app/view/transport-call-creator/transport-call-creator.component.html
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.html
@@ -41,7 +41,7 @@
     <div class="p-field col-12 md:col-6">
 
       <label for="portOfCall">{{ 'general.port.ofCall' | translate }}:</label>
-      <p-dropdown   appendTo="body" 
+      <p-dropdown   appendTo="body"
         (onChange)="portSelected()"
         formControlName="port" id="portOfCall"
         [filter]="true"
@@ -114,8 +114,14 @@
     <!-- publisherRole dropdown-->
     <div class="md:col-6" [hidden]="!showPublisherRoleOption() || !shouldCreateTimestamp()">
       <label for="timestampType">{{ 'general.publisherRole.label' | translate }}: </label>
-      <p-dropdown id="publisherRole" styleClass="dropdown" formControlName="publisherRole"
-        [options]="publisherRoleOptions" appendTo="body"></p-dropdown>
+      <p-dropdown id="publisherRole"
+                  styleClass="dropdown"
+                  formControlName="publisherRole"
+                  [options]="publisherRoleOptions"
+                  placeholder="{{ 'general.publisherRole.select' | translate }}"
+                  appendTo="body">
+
+      </p-dropdown>
     </div>
 
     <!-- create event timestamp calender-->
@@ -149,11 +155,11 @@
     <div class="md:col-6" [hidden]="!showTerminalOption() || !shouldCreateTimestamp()">
       <label for="terminal">{{ 'general.terminal.label' | translate }}:</label>
 
-      
+
       <p-dropdown appendTo="body" formControlName="terminal" id="terminal" [options]="terminals$ | async" appendTo="body"
         optionLabel="facilitySMDGCode"
         [showClear]=true
-        [filter]="true" 
+        [filter]="true"
         filterBy="facilitySMDGCode,facilityName"
         placeholder="{{ 'general.terminal.select' | translate }}">
         <ng-template let-terminal pTemplate="item">

--- a/src/app/view/transport-call-creator/transport-call-creator.component.html
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.html
@@ -119,8 +119,14 @@
                     styleClass="dropdown"
                     formControlName="publisherRole"
                     [options]="publisherRoles"
+                    [filter]="true"
+                    filterBy="publisherRoleName,publisherRole"
+                    optionLabel="publisherRoleName"
                     placeholder="{{ 'general.publisherRole.select' | translate }}"
                     appendTo="body">
+          <ng-template let-publisherRoleDetail pTemplate="item">
+            <div>{{publisherRoleDetail.publisherRoleName}} ({{publisherRoleDetail.publisherRole}})</div>
+          </ng-template>
         </p-dropdown>
       </div>
     </ng-container>

--- a/src/app/view/transport-call-creator/transport-call-creator.component.ts
+++ b/src/app/view/transport-call-creator/transport-call-creator.component.ts
@@ -73,10 +73,10 @@ export class TransportCallCreatorComponent implements OnInit {
 
   ngOnInit(): void {
     this.creationProgress = false;
-    this.portOfCalls$ = this.portService.getPorts(); 
+    this.portOfCalls$ = this.portService.getPorts();
     this.updateVesselOptions();
     this.delayCodes$ = this.delayCodeService.getDelayCodes();
-    this.negotiationCycles$ = this.timestampDefinitionService.getNegotiationCycles(); 
+    this.negotiationCycles$ = this.timestampDefinitionService.getNegotiationCycles();
     this.timestampDefinitionService.getTimestampDefinitions().pipe(take(1)).subscribe(timestampDefinitions => {
       this.timestampDefinitions = timestampDefinitions;
       this.updateTimestampTypeOptions();
@@ -181,11 +181,9 @@ export class TransportCallCreatorComponent implements OnInit {
   updatePublisherRoleOptions() {
     const timestampSelected = this.transportCallFormGroup.controls.timestampType?.value;
     this.publisherRoles = this.timestampMappingService.overlappingPublisherRoles(timestampSelected);
-    this.publisherRoleOptions = [];
-    this.publisherRoleOptions.push({ label: this.translate.instant('general.publisherRole.select'), value: null });
-    this.publisherRoles.forEach(pr => {
-      this.publisherRoleOptions.push({ label: pr, value: pr })
-    })
+    this.publisherRoleOptions = this.publisherRoles.map(pr => {
+      return { label: pr, value: pr };
+    });
   }
 
   leftPadWithZero(item: number): string {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -265,13 +265,13 @@
         "label": "Vessel Position",
         "latitude": {
           "label": "Vessel Position Latitude",
-          "maxLength": "Max length is 10 numbers!",
-          "pattern": "Latitude should only be numbers!"
+          "maxLength": "Max length is 10 characters/digits!",
+          "pattern": "Latitude should only be a number in range -90 to 90!"
         },
         "longitude": {
           "label": "Vessel Position Longitude",
-          "maxLength": "Max length is 11 numbers!",
-          "pattern": "Longitude should only be numbers!"
+          "maxLength": "Max length is 11 characters/digits!",
+          "pattern": "Longitude should only be a number in range -180 to 180!"
         }
       },
       "milesToDestinationPort": {
@@ -459,7 +459,7 @@
         "setOnce": "Once set, dimension unit cannot be edited"
       },
       "length": {
-        "name": "Length overall",   
+        "name": "Length overall",
         "pattern": "Only numbers, with at most one decimal",
         "missingUnit": "Define a Dimension unit for the vessel to use this field"
       },
@@ -479,7 +479,7 @@
             "min": "The vessel name should be at least 1 character long"
           }
         },
-        "number": { 
+        "number": {
           "empty": "The IMO is required",
           "length": {
             "max": "Maximum length is 7",


### PR DESCRIPTION
Additionally, this PR includes:

- A development configuration for `ng serve`, so it by default recompiles faster (at the expense of optimizations)
- Add `refCount` to `shareReplay` to avoid memory leaks.
- Importing a missing module (which has been missing for ages).
- Fixing a TypeError / NPE caused by a form element referencing a non-existing form control. (Not triggerable in all browser).
- Refactoring to use observable for `publisherRole` and `vesselPosition` attributes in the forms as this made it easier to support the new full names for publisher roles.